### PR TITLE
Return list of modules after compilation

### DIFF
--- a/crates/wesl-test/src/lib.rs
+++ b/crates/wesl-test/src/lib.rs
@@ -350,7 +350,7 @@ fn testsuite_test(case: WgslTestSrc) {
         let mut expect_wgsl = wgsl_parse::parse_str(&expect_wgsl)
             .inspect_err(|err| eprintln!("[FAIL] parse `expectedWgsl`: {err}"))
             .expect("parse error");
-        sort_decls(&mut case_wgsl);
+        sort_decls(&mut case_wgsl.syntax);
         sort_decls(&mut expect_wgsl);
         assert_eq!(
             normalize_wgsl(&case_wgsl.to_string()),

--- a/crates/wesl/src/import.rs
+++ b/crates/wesl/src/import.rs
@@ -95,6 +95,9 @@ impl Resolutions {
         self.order.push(path);
         module
     }
+    pub(crate) fn into_module_order(self) -> Vec<ModulePath> {
+        self.order
+    }
 }
 
 fn resolve_inline_path(

--- a/src/main.rs
+++ b/src/main.rs
@@ -544,12 +544,7 @@ fn run(cli: Cli) -> Result<(), CliError> {
         Command::Compile(args) => {
             let comp = file_or_source(args.file)
                 .map(|input| run_compile(&args.options, input))
-                .unwrap_or_else(|| {
-                    Ok(CompileResult {
-                        syntax: TranslationUnit::default(),
-                        sourcemap: None,
-                    })
-                })?;
+                .unwrap_or_else(|| Ok(CompileResult::default()))?;
             #[cfg(feature = "naga")]
             if !args.options.no_naga {
                 naga_validate(&comp.to_string())?;
@@ -559,12 +554,7 @@ fn run(cli: Cli) -> Result<(), CliError> {
         Command::Eval(args) => {
             let comp = file_or_source(args.file)
                 .map(|input| run_compile(&args.options, input))
-                .unwrap_or_else(|| {
-                    Ok(CompileResult {
-                        syntax: TranslationUnit::default(),
-                        sourcemap: None,
-                    })
-                })?;
+                .unwrap_or_else(|| Ok(CompileResult::default()))?;
             let mut eval = comp.eval(&args.expr)?;
             if args.binary {
                 let buf = eval
@@ -579,12 +569,7 @@ fn run(cli: Cli) -> Result<(), CliError> {
         Command::Exec(args) => {
             let comp = file_or_source(args.file)
                 .map(|input| run_compile(&args.options, input))
-                .unwrap_or_else(|| {
-                    Ok(CompileResult {
-                        syntax: TranslationUnit::default(),
-                        sourcemap: None,
-                    })
-                })?;
+                .unwrap_or_else(|| Ok(CompileResult::default()))?;
 
             let resources = args
                 .resources


### PR DESCRIPTION
For #14 

Also, if I run `cargo test` at the top level, cargo does not discover any tests.

Currently `cargo test` fails for me with the following exception.
```
test spec_tests::representation-check-f32-lost-bits (line 156) ... FAILED

failures:

---- spec_tests::representation-check-f32-lost-bits (line 156) stdout ----
case: `representation-check-f32-lost-bits`
* desc: Tests f32 representation issue due to lost bits.
* kind: Eval
* expect: Fail
[FAIL] expected Fail, got Pass (`1f`)

thread 'spec_tests::representation-check-f32-lost-bits (line 156)' panicked at crates\wesl-test\src\lib.rs:199:25:
test failed
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library\std\src\panicking.rs:695
   1: core::panicking::panic_fmt
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library\core\src\panicking.rs:75
   2: wgsl_test::json_case
             at .\src\lib.rs:199
   3: wgsl_test::spec_tests
             at .\src\lib.rs:129
   4: wgsl_test::__TEST_TRAMPOLINE_spec_tests
             at .\src\lib.rs:126
   5: wgsl_test::__TEST_DESCRIBE_spec_tests::closure$0::closure$0
             at .\src\lib.rs:126
   6: core::ops::function::FnOnce::call_once<wgsl_test::__TEST_DESCRIBE_spec_tests::closure$0::closure_env$0,tuple$<> >
             at C:\Users\Stefnotch\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:250
   7: alloc::boxed::impl$28::call_once<tuple$<>,dyn$<core::ops::function::FnOnce<tuple$<>,assoc$<Output,tuple$<> > >,core::marker::Send>,alloc::alloc::Global>
             at C:\Users\Stefnotch\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\boxed.rs:1970
   8: datatest::runner::render_data_test::closure$0
             at C:\Users\Stefnotch\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\datatest-0.8.0\src\runner.rs:260
   9: core::ops::function::FnOnce::call_once<datatest::runner::render_data_test::closure_env$0,tuple$<> >
             at C:\Users\Stefnotch\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:250
  10: alloc::boxed::impl$28::call_once
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library\alloc\src\boxed.rs:1970
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```