### PR TITLE
Make Span copy-able

### DIFF
--- a/crates/wesl/src/condcomp.rs
+++ b/crates/wesl/src/condcomp.rs
@@ -28,8 +28,7 @@ const EXPR_FALSE: Expression = Expression::Literal(LiteralExpression::Bool(false
 
 pub fn eval_attr(expr: &Expression, features: &Features) -> Result<Expression, E> {
     fn eval_rec(expr: &ExpressionNode, features: &Features) -> Result<Expression, E> {
-        eval_attr(expr, features)
-            .map_err(|e| Diagnostic::from(e).with_span(expr.span().clone()).into())
+        eval_attr(expr, features).map_err(|e| Diagnostic::from(e).with_span(expr.span()).into())
     }
 
     match expr {
@@ -38,7 +37,7 @@ pub fn eval_attr(expr: &Expression, features: &Features) -> Result<Expression, E
             let expr = eval_rec(&paren.expression, features)?;
             Ok(match expr {
                 Expression::Binary(_) => ParenthesizedExpression {
-                    expression: Spanned::new(expr, paren.expression.span().clone()),
+                    expression: Spanned::new(expr, paren.expression.span()),
                 }
                 .into(),
                 _ => expr,
@@ -76,8 +75,8 @@ pub fn eval_attr(expr: &Expression, features: &Features) -> Result<Expression, E
                     } else {
                         BinaryExpression {
                             operator: binary.operator,
-                            left: Spanned::new(left, binary.left.span().clone()),
-                            right: Spanned::new(right, binary.right.span().clone()),
+                            left: Spanned::new(left, binary.left.span()),
+                            right: Spanned::new(right, binary.right.span()),
                         }
                         .into()
                     };
@@ -95,8 +94,8 @@ pub fn eval_attr(expr: &Expression, features: &Features) -> Result<Expression, E
                     } else {
                         BinaryExpression {
                             operator: binary.operator,
-                            left: Spanned::new(left, binary.left.span().clone()),
-                            right: Spanned::new(right, binary.right.span().clone()),
+                            left: Spanned::new(left, binary.left.span()),
+                            right: Spanned::new(right, binary.right.span()),
                         }
                         .into()
                     };

--- a/crates/wesl/src/error.rs
+++ b/crates/wesl/src/error.rs
@@ -56,7 +56,7 @@ pub struct Diagnostic<E: std::error::Error> {
 
 impl From<wgsl_parse::Error> for Diagnostic<Error> {
     fn from(error: wgsl_parse::Error) -> Self {
-        let span = error.span.clone();
+        let span = error.span;
         let mut res = Self::new(Error::ParseError(error));
         res.span = Some(span);
         res

--- a/crates/wesl/src/eval/mod.rs
+++ b/crates/wesl/src/eval/mod.rs
@@ -201,14 +201,14 @@ impl<'s> Context<'s> {
             self.err_decl = Some(decl)
         }
     }
-    fn set_err_span_ctx(&mut self, expr: &Span) {
+    fn set_err_span_ctx(&mut self, expr: Span) {
         if self.err_span.is_none() {
-            self.err_span = Some(expr.clone())
+            self.err_span = Some(expr)
         }
     }
 
     pub fn err_ctx(&self) -> (Option<String>, Option<Span>) {
-        (self.err_decl.clone(), self.err_span.clone())
+        (self.err_decl.clone(), self.err_span)
     }
 
     pub fn set_stage(&mut self, stage: EvalStage) {

--- a/crates/wesl/src/validate/mod.rs
+++ b/crates/wesl/src/validate/mod.rs
@@ -47,9 +47,9 @@ fn check_defined_symbols(wesl: &TranslationUnit) -> Result<(), Diagnostic<Error>
     }
     fn check_expr(expr: &ExpressionNode) -> Result<(), Diagnostic<Error>> {
         if let Expression::TypeOrIdentifier(ty) = expr.node() {
-            check_ty(ty).map_err(|d| d.with_span(expr.span().clone()))
+            check_ty(ty).map_err(|d| d.with_span(expr.span()))
         } else if let Expression::FunctionCall(call) = expr.node() {
-            check_ty(&call.ty).map_err(|d| d.with_span(expr.span().clone()))?;
+            check_ty(&call.ty).map_err(|d| d.with_span(expr.span()))?;
             for expr in &call.arguments {
                 check_expr(expr)?;
             }
@@ -147,7 +147,7 @@ fn check_function_calls(wesl: &TranslationUnit) -> Result<(), Diagnostic<Error>>
         for expr in Visit::<ExpressionNode>::visit(decl) {
             check_expr(expr, wesl).map_err(|e| {
                 let mut err = Diagnostic::from(e);
-                err.span = Some(expr.span().clone());
+                err.span = Some(expr.span());
                 err.declaration = decl.ident().map(|id| id.name().to_string());
                 err
             })?;
@@ -211,7 +211,7 @@ fn check_reserved_words(wesl: &TranslationUnit) -> Result<(), Diagnostic<Error>>
     }
     fn check_stmt(stmt: &StatementNode) -> Result<(), Diagnostic<Error>> {
         if let Statement::Declaration(decl) = stmt.node() {
-            check_ident(&decl.ident).map_err(|d| d.with_span(stmt.span().clone()))?;
+            check_ident(&decl.ident).map_err(|d| d.with_span(stmt.span()))?;
         }
         for stmt in Visit::<StatementNode>::visit(stmt.node()) {
             check_stmt(stmt)?;

--- a/crates/wgsl-parse/src/span.rs
+++ b/crates/wgsl-parse/src/span.rs
@@ -5,18 +5,35 @@ use derive_more::derive::{AsMut, AsRef, Deref, DerefMut, From};
 pub type Id = u32;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Default, Clone, Debug, PartialEq, Eq, Deref, DerefMut, AsRef, AsMut, From)]
-pub struct Span(Range<usize>);
-
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Span {
+    /// The lower bound of the span (inclusive).
+    pub start: usize,
+    /// The upper bound of the span (exclusive).
+    pub end: usize,
+}
+// Deref, DerefMut, AsRef, AsMut
 impl Span {
     pub fn new(range: Range<usize>) -> Self {
-        Self(range)
+        Self {
+            start: range.start,
+            end: range.end,
+        }
     }
     pub fn range(&self) -> Range<usize> {
-        self.0.clone()
+        self.start..self.end
     }
-    pub fn extend(&self, other: &Span) -> Self {
-        Self(self.start..other.end)
+    pub fn extend(&self, other: Span) -> Self {
+        Self {
+            start: self.start,
+            end: other.end,
+        }
+    }
+}
+
+impl From<Range<usize>> for Span {
+    fn from(value: Range<usize>) -> Self {
+        Span::new(value)
     }
 }
 
@@ -46,8 +63,8 @@ impl<T> Spanned<T> {
     pub fn new_boxed(node: Box<T>, span: Span) -> Self {
         Self { span, node }
     }
-    pub fn span(&self) -> &Span {
-        &self.span
+    pub fn span(&self) -> Span {
+        self.span
     }
     pub fn node(&self) -> &T {
         self


### PR DESCRIPTION
This makes `Span` copy-able and removes all `.clone()` calls