### PR TITLE
Make attributes spanned

### DIFF
--- a/crates/wesl/src/condcomp.rs
+++ b/crates/wesl/src/condcomp.rs
@@ -120,10 +120,10 @@ pub fn eval_attr(expr: &Expression, features: &Features) -> Result<Expression, E
     }
 }
 
-fn get_single_attr(attrs: &mut [Attribute]) -> Result<Option<&mut Attribute>, E> {
+fn get_single_attr(attrs: &mut [AttributeNode]) -> Result<Option<&mut AttributeNode>, E> {
     let mut it = attrs.iter_mut().filter(|attr| {
         matches!(
-            attr,
+            attr.node(),
             Attribute::If(_) | Attribute::Elif(_) | Attribute::Else
         )
     });
@@ -156,17 +156,17 @@ fn eval_if_attr(
     let attr = get_single_attr(node.attributes_mut())?;
     let mut has_if = false;
     if let Some(attr) = attr {
-        if let Attribute::If(expr) = attr {
+        if let Attribute::If(expr) = attr.node_mut() {
             **expr = eval_attr(expr, features)?;
             has_if = true;
-        } else if let Attribute::Elif(expr) = attr {
+        } else if let Attribute::Elif(expr) = attr.node_mut() {
             if !prev.has_if {
                 return Err(CondCompError::NoPrecedingIf.into());
             } else {
                 **expr = eval_attr(expr, features)?;
                 has_if = true;
             }
-        } else if let Attribute::Else = attr {
+        } else if let Attribute::Else = attr.node() {
             if !prev.has_if {
                 return Err(CondCompError::NoPrecedingIf.into());
             }

--- a/crates/wesl/src/eval/attrs.rs
+++ b/crates/wesl/src/eval/attrs.rs
@@ -1,5 +1,5 @@
 use wgsl_parse::{
-    syntax::{Attribute, Expression},
+    syntax::{Attribute, AttributeNode, Expression},
     Decorated,
 };
 
@@ -50,12 +50,12 @@ fn eval_positive_integer(expr: &Expression, ctx: &mut Context) -> Result<u32, E>
     }
 }
 
-fn attr_group_binding(attrs: &[Attribute], ctx: &mut Context) -> Result<(u32, u32), E> {
-    let group = attrs.iter().find_map(|attr| match attr {
+fn attr_group_binding(attrs: &[AttributeNode], ctx: &mut Context) -> Result<(u32, u32), E> {
+    let group = attrs.iter().find_map(|attr| match attr.node() {
         Attribute::Group(g) => Some(g),
         _ => None,
     });
-    let binding = attrs.iter().find_map(|attr| match attr {
+    let binding = attrs.iter().find_map(|attr| match attr.node() {
         Attribute::Binding(b) => Some(b),
         _ => None,
     });
@@ -70,8 +70,8 @@ fn attr_group_binding(attrs: &[Attribute], ctx: &mut Context) -> Result<(u32, u3
     Ok((group, binding))
 }
 
-fn attr_size(attrs: &[Attribute], ctx: &mut Context) -> Option<Result<u32, E>> {
-    let expr = attrs.iter().find_map(|attr| match attr {
+fn attr_size(attrs: &[AttributeNode], ctx: &mut Context) -> Option<Result<u32, E>> {
+    let expr = attrs.iter().find_map(|attr| match attr.node() {
         Attribute::Size(e) => Some(e),
         _ => None,
     })?;
@@ -79,8 +79,8 @@ fn attr_size(attrs: &[Attribute], ctx: &mut Context) -> Option<Result<u32, E>> {
     Some(eval_positive_integer(expr, ctx))
 }
 
-fn attr_align(attrs: &[Attribute], ctx: &mut Context) -> Option<Result<u32, E>> {
-    let expr = attrs.iter().find_map(|attr| match attr {
+fn attr_align(attrs: &[AttributeNode], ctx: &mut Context) -> Option<Result<u32, E>> {
+    let expr = attrs.iter().find_map(|attr| match attr.node() {
         Attribute::Align(e) => Some(e),
         _ => None,
     })?;
@@ -88,8 +88,8 @@ fn attr_align(attrs: &[Attribute], ctx: &mut Context) -> Option<Result<u32, E>> 
     Some(eval_positive_integer(expr, ctx))
 }
 
-fn attr_id(attrs: &[Attribute], ctx: &mut Context) -> Option<Result<u32, E>> {
-    let expr = attrs.iter().find_map(|attr| match attr {
+fn attr_id(attrs: &[AttributeNode], ctx: &mut Context) -> Option<Result<u32, E>> {
+    let expr = attrs.iter().find_map(|attr| match attr.node() {
         Attribute::Id(e) => Some(e),
         _ => None,
     })?;
@@ -97,8 +97,8 @@ fn attr_id(attrs: &[Attribute], ctx: &mut Context) -> Option<Result<u32, E>> {
     Some(eval_positive_integer(expr, ctx))
 }
 
-fn attr_location(attrs: &[Attribute], ctx: &mut Context) -> Option<Result<u32, E>> {
-    let expr = attrs.iter().find_map(|attr| match attr {
+fn attr_location(attrs: &[AttributeNode], ctx: &mut Context) -> Option<Result<u32, E>> {
+    let expr = attrs.iter().find_map(|attr| match attr.node() {
         Attribute::Location(e) => Some(e),
         _ => None,
     })?;
@@ -107,12 +107,12 @@ fn attr_location(attrs: &[Attribute], ctx: &mut Context) -> Option<Result<u32, E
 }
 
 fn attr_workgroup_size(
-    attrs: &[Attribute],
+    attrs: &[AttributeNode],
     ctx: &mut Context,
 ) -> Result<(u32, Option<u32>, Option<u32>), E> {
     let attr = attrs
         .iter()
-        .find_map(|attr| match attr {
+        .find_map(|attr| match attr.node() {
             Attribute::WorkgroupSize(attr) => Some(attr),
             _ => None,
         })
@@ -132,8 +132,8 @@ fn attr_workgroup_size(
     Ok((x, y, z))
 }
 
-fn attr_blend_src(attrs: &[Attribute], ctx: &mut Context) -> Option<Result<bool, E>> {
-    let expr = attrs.iter().find_map(|attr| match attr {
+fn attr_blend_src(attrs: &[AttributeNode], ctx: &mut Context) -> Option<Result<bool, E>> {
+    let expr = attrs.iter().find_map(|attr| match attr.node() {
         Attribute::BlendSrc(attr) => Some(attr),
         _ => None,
     })?;

--- a/crates/wesl/src/eval/builtin.rs
+++ b/crates/wesl/src/eval/builtin.rs
@@ -4,9 +4,12 @@ use half::prelude::*;
 use num_traits::{real::Real, FromPrimitive, One, ToBytes, ToPrimitive, Zero};
 
 use itertools::{chain, izip, Itertools};
-use wgsl_parse::syntax::{
-    AccessMode, AddressSpace, Attribute, CustomAttribute, Expression, GlobalDeclaration, Ident,
-    LiteralExpression, TemplateArg, TranslationUnit, TypeExpression,
+use wgsl_parse::{
+    syntax::{
+        AccessMode, AddressSpace, Attribute, CustomAttribute, Expression, GlobalDeclaration, Ident,
+        LiteralExpression, TemplateArg, TranslationUnit, TypeExpression,
+    },
+    Decorated,
 };
 
 use crate::{
@@ -176,7 +179,7 @@ pub static PRELUDE: LazyLock<TranslationUnit> = LazyLock::new(|| {
     for decl in &mut prelude.global_declarations {
         match decl {
             GlobalDeclaration::Struct(s) => {
-                if s.attributes.contains(&attr_internal) {
+                if s.contains_attribute(&attr_internal) {
                     s.ident = Ident::new(format!("__{}", s.ident));
                     for m in &mut s.members {
                         repl_ty(&mut m.ty);
@@ -188,9 +191,9 @@ pub static PRELUDE: LazyLock<TranslationUnit> = LazyLock::new(|| {
                     .body
                     .attributes
                     .iter_mut()
-                    .find(|attr| **attr == attr_intrinsic)
+                    .find(|attr| attr.node() == &attr_intrinsic)
                 {
-                    *attr = ATTR_INTRINSIC.clone();
+                    *attr.node_mut() = ATTR_INTRINSIC.clone();
                 }
             }
             _ => (),

--- a/crates/wesl/src/eval/constant.rs
+++ b/crates/wesl/src/eval/constant.rs
@@ -1,6 +1,6 @@
 use super::{is_constructor_fn, Scope, SyntaxUtil};
 use itertools::Itertools;
-use wgsl_parse::{span::Spanned, syntax::*};
+use wgsl_parse::{span::Spanned, syntax::*, Decorated};
 
 macro_rules! with_scope {
     ($scope:expr, $body:tt) => {{
@@ -32,7 +32,7 @@ pub(crate) fn mark_functions_const(wesl: &mut TranslationUnit) {
     for (decl, mark_const) in wesl.global_declarations.iter_mut().zip(mark_const) {
         if let GlobalDeclaration::Function(decl) = decl {
             if mark_const {
-                decl.attributes.push(Attribute::Const)
+                decl.attributes.push(Attribute::Const.into())
             }
         }
     }
@@ -40,7 +40,7 @@ pub(crate) fn mark_functions_const(wesl: &mut TranslationUnit) {
 
 impl IsConst for Function {
     fn is_const(&self, wesl: &TranslationUnit, locals: &mut Locals) -> bool {
-        self.attributes.contains(&Attribute::Const)
+        self.contains_attribute(&Attribute::Const)
             || with_scope!(locals, {
                 self.attributes.is_const(wesl, locals)
                     && self.parameters.is_const(wesl, locals)

--- a/crates/wesl/src/eval/ty.rs
+++ b/crates/wesl/src/eval/ty.rs
@@ -10,7 +10,7 @@ use super::{
 type E = EvalError;
 
 use derive_more::derive::{IsVariant, Unwrap};
-use wgsl_parse::{span::Spanned, syntax::*};
+use wgsl_parse::{span::Spanned, syntax::*, Decorated};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, IsVariant, Unwrap)]
 pub enum SampledType {
@@ -859,7 +859,7 @@ impl EvalTy for FunctionCallExpression {
                     Ok(Type::Struct(decl.ident.to_string()))
                 }
                 GlobalDeclaration::Function(decl) => {
-                    if decl.body.attributes.contains(&ATTR_INTRINSIC) {
+                    if decl.body.contains_attribute(&ATTR_INTRINSIC) {
                         let args = self
                             .arguments
                             .iter()

--- a/crates/wesl/src/lower.rs
+++ b/crates/wesl/src/lower.rs
@@ -26,7 +26,7 @@ pub fn lower(wesl: &mut TranslationUnit) -> Result<(), Error> {
 
     for attrs in Visit::<Attributes>::visit_mut(wesl) {
         attrs.retain(|attr| {
-            !matches!(attr, 
+            !matches!(attr.node(), 
             Attribute::Custom(CustomAttribute { name, .. }) if name == "generic")
         })
     }
@@ -41,6 +41,7 @@ pub fn lower(wesl: &mut TranslationUnit) -> Result<(), Error> {
     {
         use crate::eval::{mark_functions_const, Context, Exec, Lower};
         use crate::Diagnostic;
+        use wgsl_parse::Decorated;
         mark_functions_const(wesl);
 
         // we want to drop wesl2 at the end of the block for idents use_count
@@ -55,7 +56,7 @@ pub fn lower(wesl: &mut TranslationUnit) -> Result<(), Error> {
         // remove `@const` attributes.
         for decl in &mut wesl.global_declarations {
             if let GlobalDeclaration::Function(decl) = decl {
-                decl.attributes.retain(|attr| *attr != Attribute::Const);
+                decl.retain_attributes_mut(|attr| *attr != Attribute::Const);
             }
         }
     }

--- a/crates/wesl/src/syntax_util.rs
+++ b/crates/wesl/src/syntax_util.rs
@@ -38,7 +38,7 @@ impl SyntaxUtil for TranslationUnit {
                     .iter()
                     .any(|attr| {
                         matches!(
-                            attr,
+                            attr.node(),
                             Attribute::Vertex | Attribute::Fragment | Attribute::Compute
                         )
                     })
@@ -305,7 +305,7 @@ impl SyntaxUtil for TranslationUnit {
                         let mut scope = scope.clone();
                         scope
                             .to_mut()
-                            .extend(d.attributes.iter().filter_map(|attr| match attr {
+                            .extend(d.attributes.iter().filter_map(|attr| match attr.node() {
                                 Attribute::Type(attr) => {
                                     Some((attr.ident.to_string(), attr.ident.clone()))
                                 }

--- a/crates/wgsl-parse/src/syntax.rs
+++ b/crates/wgsl-parse/src/syntax.rs
@@ -375,6 +375,8 @@ pub enum Attribute {
     Custom(CustomAttribute),
 }
 
+pub type AttributeNode = Spanned<Attribute>;
+
 #[cfg(feature = "generics")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, From)]
@@ -383,7 +385,7 @@ pub struct TypeConstraint {
     pub variants: Vec<TypeExpression>,
 }
 
-pub type Attributes = Vec<Attribute>;
+pub type Attributes = Vec<AttributeNode>;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, From, IsVariant, Unwrap)]

--- a/crates/wgsl-parse/src/syntax_display.rs
+++ b/crates/wgsl-parse/src/syntax_display.rs
@@ -396,7 +396,7 @@ impl Display for TypeConstraint {
     }
 }
 
-fn fmt_attrs(attrs: &[Attribute], inline: bool) -> impl fmt::Display + '_ {
+fn fmt_attrs(attrs: &[AttributeNode], inline: bool) -> impl fmt::Display + '_ {
     FormatFn(move |f| {
         let print = attrs.iter().format(" ");
         let suffix = if attrs.is_empty() {

--- a/crates/wgsl-parse/src/syntax_impl.rs
+++ b/crates/wgsl-parse/src/syntax_impl.rs
@@ -307,9 +307,16 @@ impl GlobalDeclaration {
 /// A trait implemented on all types that can be prefixed by attributes.
 pub trait Decorated {
     /// List all attributes (`@name`) of a syntax node.
-    fn attributes(&self) -> &[Attribute];
+    fn attributes(&self) -> &[AttributeNode];
     /// List all attributes (`@name`) of a syntax node.
-    fn attributes_mut(&mut self) -> &mut [Attribute];
+    fn attributes_mut(&mut self) -> &mut [AttributeNode];
+    /// Remove attributes with predicate.
+    fn contains_attribute(&self, attribute: &Attribute) -> bool {
+        self.attributes()
+            .iter()
+            .find(|v| v.node() == attribute)
+            .is_some()
+    }
     /// Remove attributes with predicate.
     fn retain_attributes_mut<F>(&mut self, f: F)
     where
@@ -317,36 +324,36 @@ pub trait Decorated {
 }
 
 impl<T: Decorated> Decorated for Spanned<T> {
-    fn attributes(&self) -> &[Attribute] {
+    fn attributes(&self) -> &[AttributeNode] {
         self.node().attributes()
     }
 
-    fn attributes_mut(&mut self) -> &mut [Attribute] {
+    fn attributes_mut(&mut self) -> &mut [AttributeNode] {
         self.node_mut().attributes_mut()
     }
 
-    fn retain_attributes_mut<F>(&mut self, f: F)
+    fn retain_attributes_mut<F>(&mut self, mut f: F)
     where
         F: FnMut(&mut Attribute) -> bool,
     {
-        self.node_mut().retain_attributes_mut(f)
+        self.node_mut().retain_attributes_mut(|v| f(v))
     }
 }
 
 macro_rules! impl_decorated_struct {
     ($ty:ty) => {
         impl Decorated for $ty {
-            fn attributes(&self) -> &[Attribute] {
+            fn attributes(&self) -> &[AttributeNode] {
                 &self.attributes
             }
-            fn attributes_mut(&mut self) -> &mut [Attribute] {
+            fn attributes_mut(&mut self) -> &mut [AttributeNode] {
                 &mut self.attributes
             }
-            fn retain_attributes_mut<F>(&mut self, f: F)
+            fn retain_attributes_mut<F>(&mut self, mut f: F)
             where
                 F: FnMut(&mut Attribute) -> bool,
             {
-                self.attributes.retain_mut(f)
+                self.attributes.retain_mut(|v| f(v))
             }
         }
     };
@@ -357,7 +364,7 @@ impl_decorated_struct!(ImportStatement);
 
 #[cfg(feature = "attributes")]
 impl Decorated for GlobalDirective {
-    fn attributes(&self) -> &[Attribute] {
+    fn attributes(&self) -> &[AttributeNode] {
         match self {
             GlobalDirective::Diagnostic(directive) => &directive.attributes,
             GlobalDirective::Enable(directive) => &directive.attributes,
@@ -365,7 +372,7 @@ impl Decorated for GlobalDirective {
         }
     }
 
-    fn attributes_mut(&mut self) -> &mut [Attribute] {
+    fn attributes_mut(&mut self) -> &mut [AttributeNode] {
         match self {
             GlobalDirective::Diagnostic(directive) => &mut directive.attributes,
             GlobalDirective::Enable(directive) => &mut directive.attributes,
@@ -373,14 +380,14 @@ impl Decorated for GlobalDirective {
         }
     }
 
-    fn retain_attributes_mut<F>(&mut self, f: F)
+    fn retain_attributes_mut<F>(&mut self, mut f: F)
     where
         F: FnMut(&mut Attribute) -> bool,
     {
         match self {
-            GlobalDirective::Diagnostic(directive) => directive.attributes.retain_mut(f),
-            GlobalDirective::Enable(directive) => directive.attributes.retain_mut(f),
-            GlobalDirective::Requires(directive) => directive.attributes.retain_mut(f),
+            GlobalDirective::Diagnostic(directive) => directive.attributes.retain_mut(|v| f(v)),
+            GlobalDirective::Enable(directive) => directive.attributes.retain_mut(|v| f(v)),
+            GlobalDirective::Requires(directive) => directive.attributes.retain_mut(|v| f(v)),
         }
     }
 }
@@ -396,7 +403,7 @@ impl_decorated_struct!(RequiresDirective);
 
 #[cfg(feature = "attributes")]
 impl Decorated for GlobalDeclaration {
-    fn attributes(&self) -> &[Attribute] {
+    fn attributes(&self) -> &[AttributeNode] {
         match self {
             GlobalDeclaration::Void => &[],
             GlobalDeclaration::Declaration(decl) => &decl.attributes,
@@ -407,7 +414,7 @@ impl Decorated for GlobalDeclaration {
         }
     }
 
-    fn attributes_mut(&mut self) -> &mut [Attribute] {
+    fn attributes_mut(&mut self) -> &mut [AttributeNode] {
         match self {
             GlobalDeclaration::Void => &mut [],
             GlobalDeclaration::Declaration(decl) => &mut decl.attributes,
@@ -418,17 +425,17 @@ impl Decorated for GlobalDeclaration {
         }
     }
 
-    fn retain_attributes_mut<F>(&mut self, f: F)
+    fn retain_attributes_mut<F>(&mut self, mut f: F)
     where
         F: FnMut(&mut Attribute) -> bool,
     {
         match self {
             GlobalDeclaration::Void => {}
-            GlobalDeclaration::Declaration(decl) => decl.attributes.retain_mut(f),
-            GlobalDeclaration::TypeAlias(decl) => decl.attributes.retain_mut(f),
-            GlobalDeclaration::Struct(decl) => decl.attributes.retain_mut(f),
-            GlobalDeclaration::Function(decl) => decl.attributes.retain_mut(f),
-            GlobalDeclaration::ConstAssert(decl) => decl.attributes.retain_mut(f),
+            GlobalDeclaration::Declaration(decl) => decl.attributes.retain_mut(|v| f(v)),
+            GlobalDeclaration::TypeAlias(decl) => decl.attributes.retain_mut(|v| f(v)),
+            GlobalDeclaration::Struct(decl) => decl.attributes.retain_mut(|v| f(v)),
+            GlobalDeclaration::Function(decl) => decl.attributes.retain_mut(|v| f(v)),
+            GlobalDeclaration::ConstAssert(decl) => decl.attributes.retain_mut(|v| f(v)),
         }
     }
 }
@@ -452,7 +459,7 @@ impl_decorated_struct!(ConstAssert);
 
 #[cfg(feature = "attributes")]
 impl Decorated for Statement {
-    fn attributes(&self) -> &[Attribute] {
+    fn attributes(&self) -> &[AttributeNode] {
         match self {
             Statement::Void => &[],
             Statement::Compound(stmt) => &stmt.attributes,
@@ -474,7 +481,7 @@ impl Decorated for Statement {
         }
     }
 
-    fn attributes_mut(&mut self) -> &mut [Attribute] {
+    fn attributes_mut(&mut self) -> &mut [AttributeNode] {
         match self {
             Statement::Void => &mut [],
             Statement::Compound(stmt) => &mut stmt.attributes,
@@ -496,28 +503,28 @@ impl Decorated for Statement {
         }
     }
 
-    fn retain_attributes_mut<F>(&mut self, f: F)
+    fn retain_attributes_mut<F>(&mut self, mut f: F)
     where
         F: FnMut(&mut Attribute) -> bool,
     {
         match self {
             Statement::Void => {}
-            Statement::Compound(stmt) => stmt.attributes.retain_mut(f),
-            Statement::Assignment(stmt) => stmt.attributes.retain_mut(f),
-            Statement::Increment(stmt) => stmt.attributes.retain_mut(f),
-            Statement::Decrement(stmt) => stmt.attributes.retain_mut(f),
-            Statement::If(stmt) => stmt.attributes.retain_mut(f),
-            Statement::Switch(stmt) => stmt.attributes.retain_mut(f),
-            Statement::Loop(stmt) => stmt.attributes.retain_mut(f),
-            Statement::For(stmt) => stmt.attributes.retain_mut(f),
-            Statement::While(stmt) => stmt.attributes.retain_mut(f),
-            Statement::Break(stmt) => stmt.attributes.retain_mut(f),
-            Statement::Continue(stmt) => stmt.attributes.retain_mut(f),
-            Statement::Return(stmt) => stmt.attributes.retain_mut(f),
-            Statement::Discard(stmt) => stmt.attributes.retain_mut(f),
-            Statement::FunctionCall(stmt) => stmt.attributes.retain_mut(f),
-            Statement::ConstAssert(stmt) => stmt.attributes.retain_mut(f),
-            Statement::Declaration(stmt) => stmt.attributes.retain_mut(f),
+            Statement::Compound(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::Assignment(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::Increment(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::Decrement(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::If(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::Switch(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::Loop(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::For(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::While(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::Break(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::Continue(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::Return(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::Discard(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::FunctionCall(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::ConstAssert(stmt) => stmt.attributes.retain_mut(|v| f(v)),
+            Statement::Declaration(stmt) => stmt.attributes.retain_mut(|v| f(v)),
         }
     }
 }

--- a/crates/wgsl-parse/src/wgsl.lalrpop
+++ b/crates/wgsl-parse/src/wgsl.lalrpop
@@ -320,7 +320,7 @@ StructBodyDecl: Vec<StructMember> = {
 };
 
 StructMember: StructMember = {
-    <attributes: Attribute*> <ident: MemberIdent> ":" <ty: TypeSpecifier> => StructMember {
+    <attributes: AttributeNode*> <ident: MemberIdent> ":" <ty: TypeSpecifier> => StructMember {
         attributes, ident, ty
     },
 };
@@ -395,7 +395,7 @@ OptionallyTypedIdent: (Ident, Option<TypeExpression>) = {
 
 #[cfg(not(feature = "attributes"))]
 GlobalVariableDecl: Declaration = {
-    <attributes: Attribute*> <mut decl: VariableDecl> <initializer: ("=" <ExpressionNode>)?> => {
+    <attributes: AttributeNode*> <mut decl: VariableDecl> <initializer: ("=" <ExpressionNode>)?> => {
         decl.attributes = attributes;
         decl.initializer = initializer.map(Into::into);
         decl
@@ -414,7 +414,7 @@ GlobalValueDecl: Declaration = {
             initializer: Some(initializer),
         }
     },
-    <attributes: Attribute*> "override" <id_ty: OptionallyTypedIdent> <initializer: ("=" <ExpressionNode>)?> => {
+    <attributes: AttributeNode*> "override" <id_ty: OptionallyTypedIdent> <initializer: ("=" <ExpressionNode>)?> => {
         let (ident, ty) = id_ty;
         Declaration {
             attributes,
@@ -653,7 +653,7 @@ ExpressionNode: ExpressionNode = Spanned<Expression>;
 
 
 CompoundStatement: CompoundStatement = {
-    <attributes: Attribute*> "{" <statements: StatementNode*> "}" => CompoundStatement {
+    <attributes: AttributeNode*> "{" <statements: StatementNode*> "}" => CompoundStatement {
         attributes, statements
     },
 };
@@ -702,7 +702,7 @@ DecrementStatement: DecrementStatement = {
 };
 
 IfStatement: IfStatement = {
-    <attributes: Attribute*> <if_clause: IfClause> <else_if_clauses: ElseIfClause*> <else_clause: ElseClause?> => IfStatement {
+    <attributes: AttributeNode*> <if_clause: IfClause> <else_if_clauses: ElseIfClause*> <else_clause: ElseClause?> => IfStatement {
         attributes, if_clause, else_if_clauses, else_clause
     },
 };
@@ -722,7 +722,7 @@ ElseClause: ElseClause = "else" <body: CompoundStatement> => ElseClause {
 };
 
 SwitchStatement: SwitchStatement = {
-    <attributes: Attribute*> "switch" <expression: ExpressionNode> <body: SwitchBody> => {
+    <attributes: AttributeNode*> "switch" <expression: ExpressionNode> <body: SwitchBody> => {
         let (body_attributes, clauses) = body;
         SwitchStatement {
             attributes, expression, body_attributes, clauses
@@ -730,8 +730,8 @@ SwitchStatement: SwitchStatement = {
     },
 };
 
-SwitchBody: (Vec<Attribute>, Vec<SwitchClause>) = {
-    <Attribute*> "{" <SwitchClause+> "}",
+SwitchBody: (Vec<AttributeNode>, Vec<SwitchClause>) = {
+    <AttributeNode*> "{" <SwitchClause+> "}",
 };
 
 SwitchClause: SwitchClause = {
@@ -763,7 +763,7 @@ CaseSelector: CaseSelector = {
 };
 
 LoopStatement: LoopStatement = {
-    <attributes: Attribute*> "loop" <body_attributes: Attribute*> "{" <statements: StatementNode*> <continuing: ContinuingStatement?> "}" => {
+    <attributes: AttributeNode*> "loop" <body_attributes: AttributeNode*> "{" <statements: StatementNode*> <continuing: ContinuingStatement?> "}" => {
         let body = CompoundStatement { attributes: body_attributes, statements };
         LoopStatement {
             attributes, body, continuing
@@ -772,7 +772,7 @@ LoopStatement: LoopStatement = {
 };
 
 ForStatement: ForStatement = {
-     <attributes: Attribute*> "for" "(" <header: ForHeader> ")" <body: CompoundStatement> => {
+     <attributes: AttributeNode*> "for" "(" <header: ForHeader> ")" <body: CompoundStatement> => {
         let (initializer, condition, update) = header;
         ForStatement {
             attributes, initializer: initializer.map(Into::into), condition, update: update.map(Into::into), body
@@ -811,7 +811,7 @@ ForUpdate: StatementNode = {
 };
 
 WhileStatement: WhileStatement = {
-    <attributes: Attribute*> "while" <condition: ExpressionNode> <body: CompoundStatement> => WhileStatement {
+    <attributes: AttributeNode*> "while" <condition: ExpressionNode> <body: CompoundStatement> => WhileStatement {
         attributes, condition, body
     },
 };
@@ -838,7 +838,7 @@ ContinuingStatement = "continuing" <ContinuingCompoundStatement>;
 
 #[cfg(not(feature = "attributes"))]
 ContinuingCompoundStatement: ContinuingStatement = {
-    <attributes: Attribute*> "{" <statements: StatementNode*> <break_if: BreakIfStatement?> "}" => {
+    <attributes: AttributeNode*> "{" <statements: StatementNode*> <break_if: BreakIfStatement?> "}" => {
         let body = CompoundStatement { attributes, statements };
         ContinuingStatement { body, break_if }
     },
@@ -898,14 +898,14 @@ VariableUpdatingStatement: Statement = {
 // https://www.w3.org/TR/WGSL/#functions
 
 FunctionDecl: Function = {
-    <attributes: Attribute*> <header: FunctionHeader> <body: CompoundStatement> => {
+    <attributes: AttributeNode*> <header: FunctionHeader> <body: CompoundStatement> => {
         let (ident, parameters, return_attributes, return_type) = header;
         Function { attributes, ident, parameters, return_attributes, return_type, body }
     },
 };
 
-FunctionHeader: (Ident, Vec<FormalParameter>, Vec<Attribute>, Option<TypeExpression>) = {
-    "fn" <ident: Ident> "(" <parameters: ParamList?> ")" <ret: ("->" <Attribute*> <TemplateElaboratedIdent>)?> => {
+FunctionHeader: (Ident, Vec<FormalParameter>, Vec<AttributeNode>, Option<TypeExpression>) = {
+    "fn" <ident: Ident> "(" <parameters: ParamList?> ")" <ret: ("->" <AttributeNode*> <TemplateElaboratedIdent>)?> => {
         let (return_attributes, return_type) = ret.map(|(return_attributes, return_type)| {
             (return_attributes, Some(return_type))
         }).unwrap_or_default();
@@ -919,7 +919,7 @@ ParamList: Vec<FormalParameter> = {
 };
 
 Param: FormalParameter = {
-    <attributes: Attribute*> <ident: Ident> ":" <ty: TypeSpecifier> => FormalParameter {
+    <attributes: AttributeNode*> <ident: Ident> ":" <ty: TypeSpecifier> => FormalParameter {
         attributes, ident, ty
     },
 };
@@ -937,6 +937,8 @@ Attribute: Attribute = {
             .map_err(|e| lalrpop_util::ParseError::User{ error: (l, e, r) })
     },
 };
+
+AttributeNode: AttributeNode = Spanned<Attribute>;
 
 DiagnosticControl: (DiagnosticSeverity, String) = {
     "(" <SeverityControlName> "," <DiagnosticRuleName> ","? ")",
@@ -1002,7 +1004,7 @@ pub ImportStatement: ImportStatement = {
 
 #[cfg(all(feature = "imports", feature = "attributes"))]
 pub ImportStatement: ImportStatement = {
-    <attributes: Attribute*> "import" <path: ModulePath?> <content: ImportContent> ";" => ImportStatement {
+    <attributes: AttributeNode*> "import" <path: ModulePath?> <content: ImportContent> ";" => ImportStatement {
         attributes, path: path.unwrap_or_default(), content
     }
 };
@@ -1100,21 +1102,21 @@ Keyword: String = {
 
 #[cfg(feature = "attributes")]
 EnableDirective: EnableDirective = {
-    <attributes: Attribute*> "enable" <extensions: EnableExtensionList> ";" => EnableDirective {
+    <attributes: AttributeNode*> "enable" <extensions: EnableExtensionList> ";" => EnableDirective {
         attributes, extensions
     },
 };
 
 #[cfg(feature = "attributes")]
 RequiresDirective: RequiresDirective = {
-    <attributes: Attribute*> "requires" <extensions: SoftwareExtensionList> ";" => RequiresDirective {
+    <attributes: AttributeNode*> "requires" <extensions: SoftwareExtensionList> ";" => RequiresDirective {
         attributes, extensions
     },
 };
 
 #[cfg(feature = "attributes")]
 DiagnosticDirective: DiagnosticDirective = {
-    <Attribute*> "diagnostic" <DiagnosticControl> ";" => {
+    <AttributeNode*> "diagnostic" <DiagnosticControl> ";" => {
         let (attributes, (severity, rule_name)) = (<>);
         DiagnosticDirective { attributes, severity, rule_name }
     },
@@ -1122,14 +1124,14 @@ DiagnosticDirective: DiagnosticDirective = {
 
 #[cfg(feature = "attributes")]
 StructDecl: Struct = {
-    <attributes: Attribute*> "struct" <ident: Ident> <members: StructBodyDecl> => Struct {
+    <attributes: AttributeNode*> "struct" <ident: Ident> <members: StructBodyDecl> => Struct {
         attributes, ident, members
     },
 };
 
 #[cfg(feature = "attributes")]
 TypeAliasDecl: TypeAlias = {
-    <attributes: Attribute*> "alias" <ident: Ident> "=" <ty: TypeSpecifier> => TypeAlias {
+    <attributes: AttributeNode*> "alias" <ident: Ident> "=" <ty: TypeSpecifier> => TypeAlias {
         attributes, ident, ty
     },
 };
@@ -1141,7 +1143,7 @@ VariableOrValueStatement: Declaration = {
         decl.initializer = Some(initializer);
         decl
     },
-    <attributes: Attribute*> "let" <id_ty: OptionallyTypedIdent> "=" <initializer: ExpressionNode> => {
+    <attributes: AttributeNode*> "let" <id_ty: OptionallyTypedIdent> "=" <initializer: ExpressionNode> => {
         let (ident, ty) = id_ty;
         Declaration {
             attributes,
@@ -1151,7 +1153,7 @@ VariableOrValueStatement: Declaration = {
             initializer: Some(initializer),
         }
     },
-    <attributes: Attribute*> "const" <id_ty: OptionallyTypedIdent> "=" <initializer: ExpressionNode> => {
+    <attributes: AttributeNode*> "const" <id_ty: OptionallyTypedIdent> "=" <initializer: ExpressionNode> => {
         let (ident, ty) = id_ty;
         Declaration {
             attributes,
@@ -1165,7 +1167,7 @@ VariableOrValueStatement: Declaration = {
 
 #[cfg(feature = "attributes")]
 VariableDecl: Declaration = {
-    <attributes: Attribute*> <l: @L> "var" <template_args: TemplateList?> <r: @R> <id_ty: OptionallyTypedIdent> =>? {
+    <attributes: AttributeNode*> <l: @L> "var" <template_args: TemplateList?> <r: @R> <id_ty: OptionallyTypedIdent> =>? {
         let (ident, ty) = id_ty;
         let address_space = parse_var_template(template_args)
             .map_err(|e| lalrpop_util::ParseError::User{ error: (l, e, r) })?;
@@ -1189,7 +1191,7 @@ GlobalVariableDecl: Declaration = {
 
 #[cfg(feature = "attributes")]
 GlobalValueDecl: Declaration = {
-    <attributes: Attribute*> "const" <id_ty: OptionallyTypedIdent> "=" <initializer: ExpressionNode> => {
+    <attributes: AttributeNode*> "const" <id_ty: OptionallyTypedIdent> "=" <initializer: ExpressionNode> => {
         let (ident, ty) = id_ty;
         Declaration {
             attributes,
@@ -1199,7 +1201,7 @@ GlobalValueDecl: Declaration = {
             initializer: Some(initializer),
         }
     },
-    <attributes: Attribute*> "override" <id_ty: OptionallyTypedIdent> <initializer: ("=" <ExpressionNode>)?> => {
+    <attributes: AttributeNode*> "override" <id_ty: OptionallyTypedIdent> <initializer: ("=" <ExpressionNode>)?> => {
         let (ident, ty) = id_ty;
         Declaration {
             attributes,
@@ -1253,41 +1255,41 @@ ElseClause: ElseClause = "else" <body: CompoundStatement> => ElseClause {
 
 #[cfg(feature = "attributes")]
 CaseClause: SwitchClause = {
-    <attributes: Attribute*> "case" <case_selectors: CaseSelectors> ":"? <body: CompoundStatement> => SwitchClause {
+    <attributes: AttributeNode*> "case" <case_selectors: CaseSelectors> ":"? <body: CompoundStatement> => SwitchClause {
         attributes, case_selectors, body
     },
 };
 
 #[cfg(feature = "attributes")]
 DefaultAloneClause: SwitchClause = {
-    <attributes: Attribute*> "default" ":"? <body: CompoundStatement> => SwitchClause {
+    <attributes: AttributeNode*> "default" ":"? <body: CompoundStatement> => SwitchClause {
         attributes, case_selectors: vec![CaseSelector::Default], body
     },
 };
 
 #[cfg(feature = "attributes")]
 BreakStatement: BreakStatement = {
-    <attributes: Attribute*> "break" => BreakStatement {
+    <attributes: AttributeNode*> "break" => BreakStatement {
         attributes
     },
 };
 
 #[cfg(feature = "attributes")]
 BreakIfStatement: BreakIfStatement = {
-    <attributes: Attribute*> "break" "if" <expression: ExpressionNode> ";" => BreakIfStatement {
+    <attributes: AttributeNode*> "break" "if" <expression: ExpressionNode> ";" => BreakIfStatement {
         attributes, expression
     },
 };
 
 #[cfg(feature = "attributes")]
 ContinueStatement: ContinueStatement = {
-    <attributes: Attribute*> "continue" => ContinueStatement {
+    <attributes: AttributeNode*> "continue" => ContinueStatement {
         attributes
     },
 };
 
 #[cfg(feature = "attributes")]
-ContinuingStatement: ContinuingStatement = <Attribute*> "continuing" <ContinuingCompoundStatement> => {
+ContinuingStatement: ContinuingStatement = <AttributeNode*> "continuing" <ContinuingCompoundStatement> => {
     let (attributes, mut statement) = (<>);
     statement.attributes = attributes;
     statement
@@ -1295,7 +1297,7 @@ ContinuingStatement: ContinuingStatement = <Attribute*> "continuing" <Continuing
 
 #[cfg(feature = "attributes")]
 ContinuingCompoundStatement: ContinuingStatement = {
-    <attributes: Attribute*> "{" <statements: StatementNode*> <break_if: BreakIfStatement?> "}" => {
+    <attributes: AttributeNode*> "{" <statements: StatementNode*> <break_if: BreakIfStatement?> "}" => {
         let body = CompoundStatement { attributes, statements };
         ContinuingStatement { attributes: Vec::new(), body, break_if }
     },
@@ -1303,26 +1305,26 @@ ContinuingCompoundStatement: ContinuingStatement = {
 
 #[cfg(feature = "attributes")]
 ReturnStatement: ReturnStatement = {
-    <attributes: Attribute*> "return" <expression: ExpressionNode?> => ReturnStatement {
+    <attributes: AttributeNode*> "return" <expression: ExpressionNode?> => ReturnStatement {
         attributes, expression
     },
 };
 
 #[cfg(feature = "attributes")]
 DiscardStatement: DiscardStatement = {
-    <attributes: Attribute*> "discard" => DiscardStatement {
+    <attributes: AttributeNode*> "discard" => DiscardStatement {
         attributes
     },
 };
 
 #[cfg(feature = "attributes")]
-FuncCallStatement: FunctionCallStatement = <attributes: Attribute*> <call: CallPhrase> => FunctionCallStatement {
+FuncCallStatement: FunctionCallStatement = <attributes: AttributeNode*> <call: CallPhrase> => FunctionCallStatement {
     attributes, call
 };
 
 #[cfg(feature = "attributes")]
 ConstAssertStatement: ConstAssertStatement = {
-    <attributes: Attribute*> "const_assert" <expression: ExpressionNode> => ConstAssertStatement {
+    <attributes: AttributeNode*> "const_assert" <expression: ExpressionNode> => ConstAssertStatement {
         attributes, expression
     },
 };


### PR DESCRIPTION
I noticed that this bit in `condcomp.rs` cannot emit any span information when it fails

https://github.com/wgsl-tooling-wg/wesl-rs/blob/92e78b978b426adfcb585a3fe6766605f76364f9/crates/wesl/src/condcomp.rs#L162-L173

So I tried wrapping the attributes in `Spanned`. This does change a lot of code just so that these two places could have better error reporting.

I'm not entirely sure if it's worth it, or if we should instead just add a span to the `@else` attribute. Or maybe it's good enough to report something like "attribute above the .... statement"
I suppose it depends on what else we'd be planning on doing?