### PR TITLE
Make wgsl-parse build script more granular

### DIFF
--- a/crates/wgsl-parse/build.rs
+++ b/crates/wgsl-parse/build.rs
@@ -1,3 +1,10 @@
+use lalrpop::Configuration;
+
 fn main() {
-    lalrpop::process_root().unwrap();
+    println!("cargo::rerun-if-changed=build.rs");
+    Configuration::new()
+        .use_cargo_dir_conventions()
+        .emit_rerun_directives(true)
+        .process()
+        .unwrap();
 }


### PR DESCRIPTION
This makes the build build script for wgsl-parse a bit more granular.

I tested the wgsl-parse build script with `cargo run -vvv`. Whenever it reruns the build script, the log will have entries like
```
[wgsl-parse 0.1.2] cargo::rerun-if-changed=build.rs
[wgsl-parse 0.1.2] cargo:rerun-if-changed=src\wgsl.lalrpop
[wgsl-parse 0.1.2] processing file `src\wgsl.lalrpop`
[wgsl-parse 0.1.2] cargo:rerun-if-changed=src\wgsl_recognize.lalrpop
```

When a normal .rs file in wgsl-parse changes, then the build script does not need to regenerate the entire parser code. 

