### PR TITLE
Enable doc_auto_cfg on docsrs

### DIFF
--- a/crates/wesl/Cargo.toml
+++ b/crates/wesl/Cargo.toml
@@ -35,3 +35,4 @@ mutable_key_type = "allow"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/wesl/src/lib.rs
+++ b/crates/wesl/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "eval")]
 pub mod eval;


### PR DESCRIPTION

This displays all the features in docs.rs.


![image](https://github.com/user-attachments/assets/59d79387-d909-41f4-b831-c18d0d8e8c5b)


I tested it locally with
```sh
cd crates/wesl
RUSTDOCFLAGS="--cfg docsrs" 
cargo +nightly doc --all-features
```

I can't wait for [`doc_auto_cfg`](https://doc.rust-lang.org/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg) to become stable. The tracking issue is https://github.com/rust-lang/rust/issues/43781

Then we can get rid of the `docsrs` hack, and it'd just be 
```
cd crates/wesl
cargo doc --all-features
```
