### PR TITLE
Fix SourceMapper

### DIFF
--- a/crates/wesl/src/sourcemap.rs
+++ b/crates/wesl/src/sourcemap.rs
@@ -137,9 +137,6 @@ impl Resolver for SourceMapper<'_> {
         );
         Ok(res)
     }
-    fn resolve_module(&self, path: &ModulePath) -> Result<TranslationUnit, ResolveError> {
-        self.resolver.resolve_module(path)
-    }
     fn display_name(&self, path: &ModulePath) -> Option<String> {
         self.resolver.display_name(path)
     }


### PR DESCRIPTION
Since 399cab66f249003590d0c93c23f603555f4861c0 source maps are broken, since the custom `resolve_source` is not called on `SourceMapper` when calling `SourceMapper::resolve_module`

I did not check if any other resolver were also affected by this.