### PR TITLE
Spans for global declarations

### DIFF
--- a/crates/wesl-cli/src/main.rs
+++ b/crates/wesl-cli/src/main.rs
@@ -401,7 +401,7 @@ fn parse_binding(
     let ty_expr = wgsl
         .global_declarations
         .iter()
-        .find_map(|d| match d {
+        .find_map(|d| match d.node() {
             syntax::GlobalDeclaration::Declaration(d) => {
                 let (group, binding) = d.attr_group_binding(&mut ctx).ok()?;
                 if group == b.group && binding == b.binding {

--- a/crates/wesl-test/src/lib.rs
+++ b/crates/wesl-test/src/lib.rs
@@ -277,7 +277,7 @@ fn normalize_wgsl(wgsl: &str) -> String {
 fn sort_decls(wgsl: &mut TranslationUnit) {
     type Decl = GlobalDeclaration;
     wgsl.global_declarations
-        .sort_unstable_by(|a, b| match (a, b) {
+        .sort_unstable_by(|a, b| match (a.node(), b.node()) {
             (Decl::Void, Decl::Void) => Ordering::Equal,
             (Decl::Void, Decl::Declaration(_)) => Ordering::Less,
             (Decl::Void, Decl::Struct(_)) => Ordering::Less,

--- a/crates/wesl-web/src/lib.rs
+++ b/crates/wesl-web/src/lib.rs
@@ -200,7 +200,7 @@ fn parse_binding(
     let ty_expr = wgsl
         .global_declarations
         .iter()
-        .find_map(|d| match d {
+        .find_map(|d| match d.node() {
             syntax::GlobalDeclaration::Declaration(d) => {
                 let (group, binding) = d.attr_group_binding(&mut ctx).ok()?;
                 if group == b.group && binding == b.binding {

--- a/crates/wesl/src/condcomp.rs
+++ b/crates/wesl/src/condcomp.rs
@@ -319,10 +319,10 @@ pub fn run(wesl: &mut TranslationUnit, features: &Features) -> Result<(), E> {
     eval_if_attrs(&mut wesl.global_declarations, features)?;
 
     for decl in &mut wesl.global_declarations {
-        if let GlobalDeclaration::Struct(decl) = decl {
+        if let GlobalDeclaration::Struct(decl) = decl.node_mut() {
             eval_if_attrs(&mut decl.members, features)
                 .map_err(|e| Diagnostic::from(e).with_declaration(decl.ident.to_string()))?;
-        } else if let GlobalDeclaration::Function(decl) = decl {
+        } else if let GlobalDeclaration::Function(decl) = decl.node_mut() {
             eval_if_attrs(&mut decl.parameters, features)
                 .map_err(|e| Diagnostic::from(e).with_declaration(decl.ident.to_string()))?;
             stmt_eval_if_attrs(&mut decl.body.statements, features)

--- a/crates/wesl/src/eval/builtin.rs
+++ b/crates/wesl/src/eval/builtin.rs
@@ -174,7 +174,7 @@ pub static PRELUDE: LazyLock<TranslationUnit> = LazyLock::new(|| {
     }
 
     for decl in &mut prelude.global_declarations {
-        match decl {
+        match decl.node_mut() {
             GlobalDeclaration::Struct(s) => {
                 if s.attributes.contains(&attr_internal) {
                     s.ident = Ident::new(format!("__{}", s.ident));

--- a/crates/wesl/src/eval/constant.rs
+++ b/crates/wesl/src/eval/constant.rs
@@ -18,7 +18,7 @@ pub(crate) fn mark_functions_const(wesl: &mut TranslationUnit) {
         .global_declarations
         .iter()
         .map(|decl| {
-            if let GlobalDeclaration::Function(decl) = decl {
+            if let GlobalDeclaration::Function(decl) = decl.node() {
                 locals.add(decl.ident.to_string(), true); // we suppose the function is const.
                 let is_const = decl.is_const(wesl, &mut locals);
                 if !is_const {
@@ -30,7 +30,7 @@ pub(crate) fn mark_functions_const(wesl: &mut TranslationUnit) {
         })
         .collect_vec();
     for (decl, mark_const) in wesl.global_declarations.iter_mut().zip(mark_const) {
-        if let GlobalDeclaration::Function(decl) = decl {
+        if let GlobalDeclaration::Function(decl) = decl.node_mut() {
             if mark_const {
                 decl.attributes.push(Attribute::Const)
             }

--- a/crates/wesl/src/eval/lower.rs
+++ b/crates/wesl/src/eval/lower.rs
@@ -536,7 +536,7 @@ impl Lower for TranslationUnit {
     /// expects that `exec` was called on the TU before.
     fn lower(&mut self, ctx: &mut Context) -> Result<(), E> {
         for decl in &mut self.global_declarations {
-            match decl {
+            match decl.node_mut() {
                 GlobalDeclaration::Void => Ok(()),
                 GlobalDeclaration::Declaration(decl) => {
                     decl.attributes.lower(ctx)?;
@@ -564,7 +564,7 @@ impl Lower for TranslationUnit {
                     .inspect(|&ident| ctx.set_err_decl_ctx(ident.to_string()));
             })?;
         }
-        self.global_declarations.retain(|decl| match decl {
+        self.global_declarations.retain(|decl| match decl.node() {
             GlobalDeclaration::Void => false,
             GlobalDeclaration::Declaration(decl) => decl.kind != DeclarationKind::Const,
             GlobalDeclaration::TypeAlias(_) => false,

--- a/crates/wesl/src/generics/mod.rs
+++ b/crates/wesl/src/generics/mod.rs
@@ -2,7 +2,7 @@ mod mangle;
 
 use itertools::Itertools;
 use thiserror::Error;
-use wgsl_parse::{syntax::*, Decorated};
+use wgsl_parse::{span::Spanned, syntax::*, Decorated};
 
 use crate::visit::Visit;
 
@@ -18,7 +18,8 @@ type E = GenericsError;
 pub fn generate_variants(wesl: &mut TranslationUnit) -> Result<(), E> {
     let mut new_decls = Vec::new();
     for decl in &wesl.global_declarations {
-        if let GlobalDeclaration::Function(decl) = decl {
+        let decl_span = decl.span();
+        if let GlobalDeclaration::Function(decl) = decl.node() {
             let ty_constrs = decl.attributes.iter().rev().filter_map(|attr| match attr {
                 Attribute::Type(t) => Some(t),
                 _ => None,
@@ -76,13 +77,13 @@ pub fn generate_variants(wesl: &mut TranslationUnit) -> Result<(), E> {
 
                 let new_name = mangle::mangle(&decl.ident.name(), &signature);
                 decl.ident = Ident::new(new_name);
-                new_decls.push(decl.into());
+                new_decls.push(Spanned::new(decl.into(), decl_span));
             }
         }
     }
 
     // remove generic function declarations
-    wesl.global_declarations.retain(|decl| !matches!(decl, GlobalDeclaration::Function(f) if f.attributes.iter().any(|attr| attr.is_type())));
+    wesl.global_declarations.retain(|decl| !matches!(decl.node(), GlobalDeclaration::Function(f) if f.attributes.iter().any(|attr| attr.is_type())));
 
     // add generic variants
     wesl.global_declarations.extend(new_decls);

--- a/crates/wesl/src/lower.rs
+++ b/crates/wesl/src/lower.rs
@@ -54,7 +54,7 @@ pub fn lower(wesl: &mut TranslationUnit) -> Result<(), Error> {
 
         // remove `@const` attributes.
         for decl in &mut wesl.global_declarations {
-            if let GlobalDeclaration::Function(decl) = decl {
+            if let GlobalDeclaration::Function(decl) = decl.node_mut() {
                 decl.attributes.retain(|attr| *attr != Attribute::Const);
             }
         }
@@ -70,10 +70,10 @@ fn remove_type_aliases(wesl: &mut TranslationUnit) {
         let index = wesl
             .global_declarations
             .iter()
-            .position(|decl| matches!(decl, GlobalDeclaration::TypeAlias(_)));
+            .position(|decl| matches!(decl.node(), GlobalDeclaration::TypeAlias(_)));
         index.map(|index| {
             let decl = wesl.global_declarations.swap_remove(index);
-            match decl {
+            match decl.into_inner() {
                 GlobalDeclaration::TypeAlias(alias) => alias,
                 _ => unreachable!(),
             }
@@ -98,7 +98,7 @@ fn remove_global_consts(wesl: &mut TranslationUnit) {
     let take_next_const = |wesl: &mut TranslationUnit| {
         let index = wesl.global_declarations.iter().position(|decl| {
             matches!(
-                decl,
+                decl.node(),
                 GlobalDeclaration::Declaration(Declaration {
                     kind: DeclarationKind::Const,
                     ..
@@ -107,7 +107,7 @@ fn remove_global_consts(wesl: &mut TranslationUnit) {
         });
         index.map(|index| {
             let decl = wesl.global_declarations.swap_remove(index);
-            match decl {
+            match decl.into_inner() {
                 GlobalDeclaration::Declaration(d) => d,
                 _ => unreachable!(),
             }

--- a/crates/wesl/src/sourcemap.rs
+++ b/crates/wesl/src/sourcemap.rs
@@ -137,9 +137,6 @@ impl Resolver for SourceMapper<'_> {
         );
         Ok(res)
     }
-    fn resolve_module(&self, path: &ModulePath) -> Result<TranslationUnit, ResolveError> {
-        self.resolver.resolve_module(path)
-    }
     fn display_name(&self, path: &ModulePath) -> Option<String> {
         self.resolver.display_name(path)
     }

--- a/crates/wesl/src/syntax_util.rs
+++ b/crates/wesl/src/syntax_util.rs
@@ -32,7 +32,7 @@ impl SyntaxUtil for TranslationUnit {
     fn entry_points(&self) -> impl Iterator<Item = &Ident> {
         self.global_declarations
             .iter()
-            .filter_map(|decl| match decl {
+            .filter_map(|decl| match decl.node() {
                 GlobalDeclaration::Function(decl) => decl
                     .attributes
                     .iter()
@@ -288,7 +288,7 @@ impl SyntaxUtil for TranslationUnit {
         }
 
         for decl in &mut self.global_declarations {
-            match decl {
+            match decl.node_mut() {
                 GlobalDeclaration::Void => (),
                 GlobalDeclaration::Declaration(d) => {
                     Visit::<TypeExpression>::visit_mut(d).for_each(|ty| retarget_ty(ty, &scope))

--- a/crates/wesl/src/validate/mod.rs
+++ b/crates/wesl/src/validate/mod.rs
@@ -97,7 +97,8 @@ fn check_function_calls(wesl: &TranslationUnit) -> Result<(), Diagnostic<Error>>
         let decl = wesl
             .global_declarations
             .iter()
-            .find(|decl| decl.ident().is_some_and(|id| id == ident));
+            .find(|decl| decl.ident().is_some_and(|id| id == ident))
+            .map(|decl| decl.node());
 
         match decl {
             Some(GlobalDeclaration::Function(decl)) => {
@@ -144,7 +145,7 @@ fn check_function_calls(wesl: &TranslationUnit) -> Result<(), Diagnostic<Error>>
         Ok(())
     }
     for decl in &wesl.global_declarations {
-        for expr in Visit::<ExpressionNode>::visit(decl) {
+        for expr in Visit::<ExpressionNode>::visit(decl.node()) {
             check_expr(expr, wesl).map_err(|e| {
                 let mut err = Diagnostic::from(e);
                 err.span = Some(expr.span());

--- a/crates/wesl/src/visit.rs
+++ b/crates/wesl/src/visit.rs
@@ -403,7 +403,13 @@ impl_visit! { GlobalDeclaration => ExpressionNode,
 
 impl_visit! { TranslationUnit => StatementNode,
     {
-        global_declarations.[].GlobalDeclaration::Function.body.statements.[]
+        global_declarations.[].(x => visit::<GlobalDeclaration, StatementNode>(x)),
+    }
+}
+
+impl_visit! { GlobalDeclaration => StatementNode,
+    {
+        GlobalDeclaration::Function.body.statements.[]
     }
 }
 
@@ -415,20 +421,24 @@ impl_visit! { TranslationUnit => Attributes,
             GlobalDirective::Enable.attributes,
             GlobalDirective::Requires.attributes,
         },
-        global_declarations.[].{
-            GlobalDeclaration::Declaration.attributes,
-            GlobalDeclaration::TypeAlias.attributes,
-            GlobalDeclaration::Struct.{
-                attributes,
-                members.[].attributes,
-            },
-            GlobalDeclaration::Function.{
-                attributes,
-                parameters.[].attributes,
-                body.{ attributes, statements.[].(x => visit::<Statement, Attributes>(x)) }
-            },
-            GlobalDeclaration::ConstAssert.attributes,
-        }
+        global_declarations.[].(x => visit::<GlobalDeclaration, Attributes>(x)),
+    }
+}
+
+impl_visit! { GlobalDeclaration => Attributes,
+    {
+        GlobalDeclaration::Declaration.attributes,
+        GlobalDeclaration::TypeAlias.attributes,
+        GlobalDeclaration::Struct.{
+            attributes,
+            members.[].attributes,
+        },
+        GlobalDeclaration::Function.{
+            attributes,
+            parameters.[].attributes,
+            body.{ attributes, statements.[].(x => visit::<Statement, Attributes>(x)) }
+        },
+        GlobalDeclaration::ConstAssert.attributes,
     }
 }
 

--- a/crates/wgsl-parse/src/syntax.rs
+++ b/crates/wgsl-parse/src/syntax.rs
@@ -36,7 +36,7 @@ pub struct TranslationUnit {
     #[cfg(feature = "imports")]
     pub imports: Vec<ImportStatement>,
     pub global_directives: Vec<GlobalDirective>,
-    pub global_declarations: Vec<GlobalDeclaration>,
+    pub global_declarations: Vec<GlobalDeclarationNode>,
 }
 
 /// Identifiers correspond to WGSL `ident` syntax node, except that they have several
@@ -188,6 +188,8 @@ pub enum GlobalDeclaration {
     Function(Function),
     ConstAssert(ConstAssert),
 }
+
+pub type GlobalDeclarationNode = Spanned<GlobalDeclaration>;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/wgsl-parse/src/syntax_display.rs
+++ b/crates/wgsl-parse/src/syntax_display.rs
@@ -48,7 +48,7 @@ impl Display for TranslationUnit {
         let declarations = self
             .global_declarations
             .iter()
-            .filter(|decl| !matches!(decl, GlobalDeclaration::Void))
+            .filter(|decl| !matches!(decl.node(), GlobalDeclaration::Void))
             .format("\n\n");
         writeln!(f, "{declarations}")
     }

--- a/crates/wgsl-parse/src/syntax_impl.rs
+++ b/crates/wgsl-parse/src/syntax_impl.rs
@@ -12,13 +12,14 @@ impl TranslationUnit {
 
     /// Remove all [`GlobalDeclaration::Void`] and [`Statement::Void`]
     pub fn remove_voids(&mut self) {
-        self.global_declarations.retain_mut(|decl| match decl {
-            GlobalDeclaration::Void => false,
-            _ => {
-                decl.remove_voids();
-                true
-            }
-        })
+        self.global_declarations
+            .retain_mut(|decl| match decl.node() {
+                GlobalDeclaration::Void => false,
+                _ => {
+                    decl.remove_voids();
+                    true
+                }
+            })
     }
 }
 

--- a/crates/wgsl-parse/src/wgsl.lalrpop
+++ b/crates/wgsl-parse/src/wgsl.lalrpop
@@ -168,7 +168,7 @@ Keyword: String = {
 
 #[cfg(not(feature = "imports"))]
 pub TranslationUnit: TranslationUnit = {
-    <global_directives: GlobalDirective*> <global_declarations: GlobalDecl*> => TranslationUnit {
+    <global_directives: GlobalDirective*> <global_declarations: GlobalDeclarationNode*> => TranslationUnit {
         global_directives, global_declarations
     },
 };
@@ -182,6 +182,8 @@ pub GlobalDecl: GlobalDeclaration = {
     <FunctionDecl>             => GlobalDeclaration::Function(<>),
     <ConstAssertStatement> ";" => GlobalDeclaration::ConstAssert(<>),
 };
+
+GlobalDeclarationNode: GlobalDeclarationNode = Spanned<GlobalDecl>;
 
 DiagnosticRuleName: String = {
     DiagnosticNameToken,
@@ -988,7 +990,7 @@ TemplateElaboratedIdent: TypeExpression = <path: ModulePath?> <ident: Ident> <te
 
 #[cfg(feature = "imports")]
 pub TranslationUnit: TranslationUnit = {
-    <imports: ImportStatement*> <global_directives: GlobalDirective*> <global_declarations: GlobalDecl*> => TranslationUnit {
+    <imports: ImportStatement*> <global_directives: GlobalDirective*> <global_declarations: GlobalDeclarationNode*> => TranslationUnit {
         imports, global_directives, global_declarations
     },
 };


### PR DESCRIPTION
Addresses #60

I used `Spanned` in the grammar and then fixed all issues from there (mostly adding `node()`/`node_mut()`).

(Builds on top of #62)