### PR TITLE
Span StructMembers

### DIFF
--- a/crates/wesl/src/visit.rs
+++ b/crates/wesl/src/visit.rs
@@ -474,10 +474,13 @@ impl_visit! { TypeAlias => TypeExpression,
 impl_visit! { Struct => TypeExpression,
     {
         attributes.[].(x => visit::<Attribute, TypeExpression>(x)),
-        members.[].{
-            attributes.[].(x => visit::<Attribute, TypeExpression>(x)),
-            ty,
-        },
+        members.[].(x => visit::<StructMember, TypeExpression>(x)),
+    }
+}
+impl_visit! { StructMember => TypeExpression,
+    {
+        attributes.[].(x => visit::<Attribute, TypeExpression>(x)),
+        ty,
     }
 }
 impl_visit! { Function => TypeExpression,

--- a/crates/wgsl-parse/src/syntax.rs
+++ b/crates/wgsl-parse/src/syntax.rs
@@ -244,7 +244,7 @@ pub struct Struct {
     #[cfg(feature = "attributes")]
     pub attributes: Attributes,
     pub ident: Ident,
-    pub members: Vec<StructMember>,
+    pub members: Vec<StructMemberNode>,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -254,6 +254,8 @@ pub struct StructMember {
     pub ident: Ident,
     pub ty: TypeExpression,
 }
+
+pub type StructMemberNode = Spanned<StructMember>;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/wgsl-parse/src/wgsl.lalrpop
+++ b/crates/wgsl-parse/src/wgsl.lalrpop
@@ -317,8 +317,8 @@ StructDecl: Struct = {
     },
 };
 
-StructBodyDecl: Vec<StructMember> = {
-    "{" <Comma1<StructMember>> "}",
+StructBodyDecl: Vec<StructMemberNode> = {
+    "{" <Comma1<StructMemberNode>> "}",
 };
 
 StructMember: StructMember = {
@@ -326,6 +326,8 @@ StructMember: StructMember = {
         attributes, ident, ty
     },
 };
+
+StructMemberNode: StructMemberNode = Spanned<StructMember>;
 
 #[cfg(not(feature = "attributes"))]
 TypeAliasDecl: TypeAlias = {


### PR DESCRIPTION
Spans for struct members. This is needed for https://github.com/jannik4/wesl_docs/issues/1.
No hurry in merging this, if you want to merge the other span related PRs first.