### PR TITLE
Fetch test cases automatically

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "crates/wesl-test/wesl-testsuite"]
 	path = crates/wesl-test/wesl-testsuite
 	url = https://github.com/wgsl-tooling-wg/wesl-testsuite
+	branch = fix-14

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "crates/wesl-test/wesl-testsuite"]
 	path = crates/wesl-test/wesl-testsuite
 	url = https://github.com/wgsl-tooling-wg/wesl-testsuite
-	branch = fix-14
+	branch = main

--- a/crates/wesl-test/src/schemas.rs
+++ b/crates/wesl-test/src/schemas.rs
@@ -23,6 +23,23 @@ pub struct WgslTestSrc {
     pub underscore_wgsl: Option<String>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WgslBulkTest {
+    pub name: String,
+    pub base_dir: String,
+    pub git: Option<WgslGitSrc>,
+    pub include: Option<Vec<String>>,
+    pub exclude: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WgslGitSrc {
+    pub url: String,
+    pub revision: String,
+}
+
 impl WgslTestSrc {
     pub fn normalize(&mut self) {
         self.wesl_src.values_mut().for_each(|src| {

--- a/crates/wesl-test/tests/testsuite.rs
+++ b/crates/wesl-test/tests/testsuite.rs
@@ -385,7 +385,7 @@ pub fn validation_case(input: &str) -> Result<(), libtest_mimic::Failed> {
         condcomp: true,
         generics: false,
         strip: false,
-        lower: true,
+        lower: false,
         validate: true,
         ..Default::default()
     };

--- a/crates/wesl/src/eval/builtin.rs
+++ b/crates/wesl/src/eval/builtin.rs
@@ -1972,9 +1972,9 @@ fn call_mat_t(
 
             Ok(MatInstance::from_cols(args).into())
         } else {
-            return Err(E::Builtin(
+            Err(E::Builtin(
                 "matrix constructor expects float or vector of float arguments",
-            ));
+            ))
         }
     }
 }
@@ -2025,9 +2025,9 @@ fn call_mat(c: usize, r: usize, args: &[Instance]) -> Result<Instance, E> {
 
             Ok(MatInstance::from_cols(args).into())
         } else {
-            return Err(E::Builtin(
+            Err(E::Builtin(
                 "matrix constructor expects float or vector of float arguments",
-            ));
+            ))
         }
     }
 }


### PR DESCRIPTION
Uses https://github.com/wgsl-tooling-wg/wesl-testsuite/pull/18

The upsides of this are
- fewer git submodules yaaay
  - you can still directly edit those test cases, since it does check them out as valid git repositories
- much less network traffic for large repos
  - it does a shallow clone
