### PR TITLE
C bindings

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -17,6 +17,7 @@
       "wesl-rs",
       "wesl-test",
       "wesl-web",
+      "wesl-c",
       ".wesl",
       "WESL",
       "wgsl-parse",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wesl-c"
+version = "0.2.0"
+dependencies = [
+ "wesl",
+]
+
+[[package]]
 name = "wesl-cli"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ members = [
     "crates/wesl-macros",
     "crates/wesl",
     "crates/wesl-test",
-    "crates/wesl-web",
     "crates/wesl-cli",
+    "crates/wesl-web",
+    "crates/wesl-c",
     "crates/tokrepr",
     "crates/tokrepr-derive",
     "examples/random_wgsl",
     "examples/wesl-consumer",
-    "crates/wesl-c",
 ]
 
 resolver = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/tokrepr-derive",
     "examples/random_wgsl",
     "examples/wesl-consumer",
+    "crates/wesl-c",
 ]
 
 resolver = "3"

--- a/crates/wesl-c/Cargo.toml
+++ b/crates/wesl-c/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "wesl-c"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "staticlib"]
+
+[dependencies]
+wesl = { workspace = true }
+
+[lints]
+workspace = true
+
+[features]
+eval = ["wesl/eval"]
+generics = ["wesl/generics"]

--- a/crates/wesl-c/README.md
+++ b/crates/wesl-c/README.md
@@ -4,7 +4,7 @@ C bindings for the [`wesl-rs`][wesl-rs] compiler.
 
 [Usage examples](./examples)
 
-# Building
+## Building
 
 ```bash
 cargo build --package wesl-c --features eval,generics --release

--- a/crates/wesl-c/README.md
+++ b/crates/wesl-c/README.md
@@ -1,0 +1,14 @@
+# wesl-c
+
+C bindings for the [`wesl-rs`][wesl-rs] compiler.
+
+[Usage examples](./examples)
+
+# Building
+
+```bash
+cargo build --package wesl-c --features eval,generics --release
+# libraries should be located in target/release
+```
+
+[wesl-rs]: https://github.com/wgsl-tooling-wg/wesl-rs

--- a/crates/wesl-c/examples/.gitignore
+++ b/crates/wesl-c/examples/.gitignore
@@ -1,0 +1,5 @@
+*
+!*.c
+!.gitignore
+!*.bat
+!*.sh

--- a/crates/wesl-c/examples/build_examples.bat
+++ b/crates/wesl-c/examples/build_examples.bat
@@ -1,0 +1,29 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem cargo build
+rem NOTE: make sure you are using the GNU toolchain.
+set RUSTFLAGS=--print=native-static-libs
+cargo build --package wesl-c --features eval,generics --release
+
+rem set paths
+set WESL_LIB_PATH=../../../target/release
+set INCLUDE_PATH=../include
+
+rem build
+clang ^
+    simple.c ^
+    -I%INCLUDE_PATH% ^
+    -L%WESL_LIB_PATH% ^
+    -lwesl_c ^
+    -lkernel32 ^
+    -lntdll ^
+    -luserenv ^
+    -lws2_32 ^
+    -ldbghelp ^
+    -o simple.exe
+
+if %ERRORLEVEL% NEQ 0 (
+    echo build failed
+    exit /b 1
+)

--- a/crates/wesl-c/examples/build_examples.sh
+++ b/crates/wesl-c/examples/build_examples.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# cargo build
+RUSTFLAGS="--print=native-static-libs" cargo build --package wesl-c --features eval,generics --release
+
+# set paths
+WESL_LIB_PATH="../../../target/release"
+INCLUDE_PATH="../include"
+
+# build
+clang \
+    simple.c \
+    -I"${INCLUDE_PATH}" \
+    -L"${WESL_LIB_PATH}" \
+    -lwesl_c \
+    -o simple

--- a/crates/wesl-c/examples/simple.c
+++ b/crates/wesl-c/examples/simple.c
@@ -1,0 +1,138 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include "../include/wesl.h"
+
+// -- helpers
+WeslStringMap create_string_map(const char** keys, const char** values, size_t len) {
+    WeslStringMap map = {
+        .keys = keys,
+        .values = values,
+        .len = len
+    };
+    return map;
+}
+
+WeslBoolMap create_bool_map(const char** keys, const bool* values, size_t len) {
+    WeslBoolMap map = {
+        .keys = keys,
+        .values = values,
+        .len = len
+    };
+    return map;
+}
+
+int main() {
+    // print version
+    const char* version = wesl_version();
+    printf("WESL version: %s\n", version);
+    wesl_free_string(version);
+
+    // add some modules
+    const char* modules[] = {
+        "package::main",
+        "package::utils"
+    };
+
+    const char* sources[] = {
+        "import package::utils::add;\nfn some_fn_in_main() -> i32 { let a = add(1, 2); return a; } ",
+        "fn add(a: i32, b: i32) -> i32 { return a + b; } "
+    };
+
+    // file map
+    WeslStringMap file_map = create_string_map(modules, sources, 2);
+
+    // setup compile options
+    WeslCompileOptions options = {
+        .mangler = WESL_MANGLER_NONE,
+        .sourcemap = true,
+        .imports = true,
+        .condcomp = true,
+        .generics = true,
+        .strip = false,
+        .lower = true,
+        .validate = true,
+        .naga = true,
+        .lazy = false,
+        .keep_root = true,
+        .mangle_root = false
+    };
+
+    // setup features
+    const char* feature_keys[] = {"debug"};
+    bool feature_values[] = {true};
+    WeslBoolMap features = create_bool_map(feature_keys, feature_values, 1);
+
+    // compile
+    printf("calling wesl_compile...\n");
+    WeslResult result = wesl_compile(
+        &file_map,
+        "package::main",
+        &options,
+        NULL,   // omit keep array
+        &features
+    );
+
+    if (result.success) {
+        printf("Compilation successful!\n");
+        printf("Output:\n%s\n", result.data);
+
+        // evaluate
+        const char* eval_modules[] = {
+            "package::source"
+        };
+
+        const char* eval_sources[] = {
+            "const my_const = 4; @const fn my_fn(v: u32) -> u32 { return v * 10; }",
+        };
+
+        WeslStringMap eval_file_map = create_string_map(eval_modules, eval_sources, 1);
+
+        printf("\ncalling wesl_eval...\n");
+        WeslCompileOptions eval_options = {};
+        WeslResult eval_result = wesl_eval(
+            &eval_file_map,
+            "package::source",
+            "my_fn(my_const) + 2",
+            &eval_options,
+            &features
+        );
+
+        if (eval_result.success) {
+            printf("Evaluation successful!\n");
+            printf("Result: %s (expected: 42u)\n", eval_result.data);
+            assert(strcmp(eval_result.data, "42u") == 0 && "wesl_eval produced unexpected result");
+        } else {
+            printf("Evaluation failed!\n");
+            printf("%s\n", eval_result.error.message);
+            if (eval_result.error.diagnostics_len > 0) {
+                printf("Diagnostic: %s at %s (%u:%u)\n",
+                    eval_result.error.diagnostics[0].title,
+                    eval_result.error.diagnostics[0].file,
+                    eval_result.error.diagnostics[0].span_start,
+                    eval_result.error.diagnostics[0].span_end
+                );
+            }
+        }
+
+        // cleanup
+        wesl_free_result(&eval_result);
+    } else {
+        printf("Compilation failed!\n");
+        printf("%s\n", result.error.message);
+        if (result.error.diagnostics_len > 0) {
+            printf("Diagnostic: %s at %s (%u:%u)\n",
+                result.error.diagnostics[0].title,
+                result.error.diagnostics[0].file,
+                result.error.diagnostics[0].span_start,
+                result.error.diagnostics[0].span_end
+            );
+        }
+    }
+
+    // cleanup
+    wesl_free_result(&result);
+    
+    return 0;
+}

--- a/crates/wesl-c/examples/simple.c
+++ b/crates/wesl-c/examples/simple.c
@@ -27,7 +27,6 @@ int main() {
     // print version
     const char* version = wesl_version();
     printf("WESL version: %s\n", version);
-    wesl_free_string(version);
 
     // add some modules
     const char* modules[] = {

--- a/crates/wesl-c/examples/simple.c
+++ b/crates/wesl-c/examples/simple.c
@@ -90,7 +90,7 @@ int main() {
         WeslStringMap eval_file_map = create_string_map(eval_modules, eval_sources, 1);
 
         printf("\ncalling wesl_eval...\n");
-        WeslCompileOptions eval_options = {};
+        WeslCompileOptions eval_options = {0};
         WeslResult eval_result = wesl_eval(
             &eval_file_map,
             "package::source",

--- a/crates/wesl-c/include/wesl.h
+++ b/crates/wesl-c/include/wesl.h
@@ -11,7 +11,6 @@ extern "C" {
 
 // -- handles
 typedef struct WeslCompiler WeslCompiler;
-typedef struct WeslCompileResult WeslCompileResult;
 
 // -- enums
 typedef enum WeslManglerKind {
@@ -149,7 +148,6 @@ WeslExecResult wesl_exec(
 // -- memory
 void wesl_free_string(const char* ptr);
 void wesl_free_result(WeslResult* result);
-void wesl_free_compile_result(WeslCompileResult* result);
 void wesl_free_exec_result(WeslExecResult* result);
 
 // -- utility

--- a/crates/wesl-c/include/wesl.h
+++ b/crates/wesl-c/include/wesl.h
@@ -103,6 +103,19 @@ typedef struct WeslResult {
     WeslError error;
 } WeslResult;
 
+typedef struct WeslExecOptions {
+    WeslCompileOptions compile;
+    const char* entrypoint;
+    const WeslBindingArray* resources;
+    const WeslStringMap* overrides;
+} WeslExecOptions;
+
+typedef struct WeslExecResult {
+    bool success;
+    const WeslBindingArray* resources;
+    WeslError error;
+} WeslExecResult;
+
 // -- main API
 WeslCompiler* wesl_create_compiler(void);
 void wesl_destroy_compiler(WeslCompiler* compiler);
@@ -123,10 +136,21 @@ WeslResult wesl_eval(
     const WeslBoolMap* features
 );
 
+WeslExecResult wesl_exec(
+    const WeslStringMap* files,
+    const char* root,
+    const char* entrypoint,
+    const WeslCompileOptions* options,
+    const WeslBindingArray* resources,
+    const WeslStringMap* overrides,
+    const WeslBoolMap* features
+);
+
 // -- memory
 void wesl_free_string(const char* ptr);
 void wesl_free_result(WeslResult* result);
 void wesl_free_compile_result(WeslCompileResult* result);
+void wesl_free_exec_result(WeslExecResult* result);
 
 // -- utility
 const char* wesl_version(void);

--- a/crates/wesl-c/include/wesl.h
+++ b/crates/wesl-c/include/wesl.h
@@ -153,6 +153,8 @@ void wesl_free_compile_result(WeslCompileResult* result);
 void wesl_free_exec_result(WeslExecResult* result);
 
 // -- utility
+
+// note: results from this function must not be freed
 const char* wesl_version(void);
 
 #ifdef __cplusplus

--- a/crates/wesl-c/include/wesl.h
+++ b/crates/wesl-c/include/wesl.h
@@ -1,0 +1,138 @@
+#ifndef WESL_H
+#define WESL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// -- handles
+typedef struct WeslCompiler WeslCompiler;
+typedef struct WeslCompileResult WeslCompileResult;
+
+// -- enums
+typedef enum WeslManglerKind {
+    WESL_MANGLER_ESCAPE = 0,
+    WESL_MANGLER_HASH = 1,
+    WESL_MANGLER_NONE = 2
+} WeslManglerKind;
+
+typedef enum WeslBindingType {
+    WESL_BINDING_UNIFORM = 0,
+    WESL_BINDING_STORAGE = 1,
+    WESL_BINDING_READ_ONLY_STORAGE = 2,
+    WESL_BINDING_FILTERING = 3,
+    WESL_BINDING_NON_FILTERING = 4,
+    WESL_BINDING_COMPARISON = 5,
+    WESL_BINDING_FLOAT = 6,
+    WESL_BINDING_UNFILTERABLE_FLOAT = 7,
+    WESL_BINDING_SINT = 8,
+    WESL_BINDING_UINT = 9,
+    WESL_BINDING_DEPTH = 10,
+    WESL_BINDING_WRITE_ONLY = 11,
+    WESL_BINDING_READ_WRITE = 12,
+    WESL_BINDING_READ_ONLY = 13
+} WeslBindingType;
+
+// -- structs
+typedef struct WeslBinding {
+    unsigned int group;
+    unsigned int binding;
+    WeslBindingType kind;
+    const uint8_t* data;
+    size_t data_len;
+} WeslBinding;
+
+typedef struct WeslCompileOptions {
+    WeslManglerKind mangler;
+    bool sourcemap;
+    bool imports;
+    bool condcomp;
+    bool generics;
+    bool strip;
+    bool lower;
+    bool validate;
+    bool naga;
+    bool lazy;
+    bool keep_root;
+    bool mangle_root;
+} WeslCompileOptions;
+
+typedef struct WeslStringMap {
+    const char* const* keys;
+    const char* const* values;
+    size_t len;
+} WeslStringMap;
+
+typedef struct WeslBoolMap {
+    const char* const* keys;
+    const bool* values;
+    size_t len;
+} WeslBoolMap;
+
+typedef struct WeslStringArray {
+    const char* const* items;
+    size_t len;
+} WeslStringArray;
+
+typedef struct WeslBindingArray {
+    const WeslBinding* items;
+    size_t len;
+} WeslBindingArray;
+
+typedef struct WeslDiagnostic {
+    const char* file;
+    unsigned int span_start;
+    unsigned int span_end;
+    const char* title;
+} WeslDiagnostic;
+
+typedef struct WeslError {
+    const char* source;
+    const char* message;
+    const WeslDiagnostic* diagnostics;
+    size_t diagnostics_len;
+} WeslError;
+
+typedef struct WeslResult {
+    bool success;
+    const char* data;
+    WeslError error;
+} WeslResult;
+
+// -- main API
+WeslCompiler* wesl_create_compiler(void);
+void wesl_destroy_compiler(WeslCompiler* compiler);
+
+WeslResult wesl_compile(
+    const WeslStringMap* files,
+    const char* root,
+    const WeslCompileOptions* options,
+    const WeslStringArray* keep,
+    const WeslBoolMap* features
+);
+
+WeslResult wesl_eval(
+    const WeslStringMap* files,
+    const char* root,
+    const char* expression,
+    const WeslCompileOptions* options,
+    const WeslBoolMap* features
+);
+
+// -- memory
+void wesl_free_string(const char* ptr);
+void wesl_free_result(WeslResult* result);
+void wesl_free_compile_result(WeslCompileResult* result);
+
+// -- utility
+const char* wesl_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // WESL_H

--- a/crates/wesl-c/src/lib.rs
+++ b/crates/wesl-c/src/lib.rs
@@ -892,7 +892,9 @@ pub unsafe extern "C" fn wesl_free_exec_result(result: *mut WeslExecResult) {
 
 // -- utility
 
+// note: results from this function must not be freed
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wesl_version() -> *const c_char {
-    create_c_string(env!("CARGO_PKG_VERSION"))
+    const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "\0");
+    return VERSION.as_ptr() as *const c_char;
 }

--- a/crates/wesl-c/src/lib.rs
+++ b/crates/wesl-c/src/lib.rs
@@ -5,6 +5,12 @@ use std::ptr;
 
 use wesl::{CompileResult, VirtualResolver, Wesl};
 
+#[cfg(feature = "eval")]
+use wesl::{
+    eval::{Eval, EvalAttrs, HostShareable, Inputs, Instance, RefInstance},
+    syntax::{AccessMode, AddressSpace},
+};
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub enum WeslManglerKind {
@@ -43,6 +49,7 @@ pub enum WeslBindingType {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct WeslBinding {
     pub group: c_uint,
     pub binding: c_uint,
@@ -113,6 +120,21 @@ pub struct WeslError {
 pub struct WeslResult {
     pub success: bool,
     pub data: *const c_char,
+    pub error: WeslError,
+}
+
+#[repr(C)]
+pub struct WeslExecOptions {
+    pub compile: WeslCompileOptions,
+    pub entrypoint: *const c_char,
+    pub resources: *const WeslBindingArray,
+    pub overrides: *const WeslStringMap,
+}
+
+#[repr(C)]
+pub struct WeslExecResult {
+    pub success: bool,
+    pub resources: *const WeslBindingArray,
     pub error: WeslError,
 }
 
@@ -243,6 +265,103 @@ fn wesl_error_to_c(e: wesl::Error) -> WeslError {
     }
 }
 
+#[cfg(feature = "eval")]
+unsafe fn binding_array_to_vec(array: *const WeslBindingArray) -> Vec<WeslBinding> {
+    if array.is_null() {
+        return Vec::new();
+    }
+
+    unsafe {
+        let array = &*array;
+        let mut result = Vec::new();
+
+        for i in 0..array.len {
+            let binding = *array.items.add(i);
+            result.push(binding);
+        }
+
+        result
+    }
+}
+
+#[cfg(feature = "eval")]
+fn parse_c_binding(
+    b: &WeslBinding,
+    wgsl: &wesl::syntax::TranslationUnit,
+) -> Result<((u32, u32), RefInstance), wesl::Error> {
+    let mut ctx = wesl::eval::Context::new(wgsl);
+
+    let ty_expr = wgsl
+        .global_declarations
+        .iter()
+        .find_map(|d| match d.node() {
+            wesl::syntax::GlobalDeclaration::Declaration(d) => {
+                let (group, binding) = d.attr_group_binding(&mut ctx).ok()?;
+                if group == b.group && binding == b.binding {
+                    d.ty.clone()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .ok_or_else(|| {
+            wesl::Error::Custom(format!(
+                "Resource @group({}) @binding({}) not found",
+                b.group, b.binding
+            ))
+        })?;
+
+    let ty = wesl::eval::ty_eval_ty(&ty_expr, &mut ctx)
+        .map_err(|e| wesl::Error::Custom(format!("Failed to evaluate type: {}", e)))?;
+
+    let (storage, access) = match b.kind {
+        WeslBindingType::Uniform => (AddressSpace::Uniform, AccessMode::Read),
+        WeslBindingType::Storage => (
+            AddressSpace::Storage(Some(AccessMode::ReadWrite)),
+            AccessMode::ReadWrite,
+        ),
+        WeslBindingType::ReadOnlyStorage => (
+            AddressSpace::Storage(Some(AccessMode::Read)),
+            AccessMode::Read,
+        ),
+        _ => return Err(wesl::Error::Custom("Unsupported binding type".to_string())),
+    };
+
+    let data_slice = unsafe { std::slice::from_raw_parts(b.data, b.data_len) };
+    let inst = Instance::from_buffer(data_slice, &ty, &mut ctx).ok_or_else(|| {
+        wesl::Error::Custom(format!(
+            "Resource @group({}) @binding({}) ({} bytes) incompatible with type ({} bytes)",
+            b.group,
+            b.binding,
+            b.data_len,
+            ty.size_of(&mut ctx).unwrap_or_default()
+        ))
+    })?;
+
+    Ok((
+        (b.group, b.binding),
+        RefInstance::new(inst, storage, access),
+    ))
+}
+
+#[cfg(feature = "eval")]
+fn create_c_binding_array(bindings: Vec<WeslBinding>) -> *const WeslBindingArray {
+    if bindings.is_empty() {
+        return ptr::null();
+    }
+
+    let items = bindings.into_boxed_slice();
+    let len = items.len();
+    let items_ptr = Box::into_raw(items) as *const WeslBinding;
+
+    let array = Box::new(WeslBindingArray {
+        items: items_ptr,
+        len,
+    });
+    Box::into_raw(array)
+}
+
 // -- main API
 
 #[unsafe(no_mangle)]
@@ -357,6 +476,7 @@ pub unsafe extern "C" fn wesl_compile(
     }
 }
 
+#[cfg(feature = "eval")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wesl_eval(
     files: *const WeslStringMap,
@@ -457,6 +577,221 @@ pub unsafe extern "C" fn wesl_eval(
     }
 }
 
+#[cfg(not(feature = "eval"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_eval(
+    _files: *const WeslStringMap,
+    _root: *const c_char,
+    _expression: *const c_char,
+    _options: *const WeslCompileOptions,
+    _features: *const WeslBoolMap,
+) -> WeslResult {
+    WeslResult {
+        success: false,
+        data: ptr::null(),
+        error: WeslError {
+            source: ptr::null(),
+            message: create_c_string("wesl_eval requires the 'eval' feature to be enabled"),
+            diagnostics: ptr::null(),
+            diagnostics_len: 0,
+        },
+    }
+}
+
+#[cfg(feature = "eval")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_exec(
+    files: *const WeslStringMap,
+    root: *const c_char,
+    entrypoint: *const c_char,
+    options: *const WeslCompileOptions,
+    resources: *const WeslBindingArray,
+    overrides: *const WeslStringMap,
+    features: *const WeslBoolMap,
+) -> WeslExecResult {
+    if files.is_null() || root.is_null() || entrypoint.is_null() || options.is_null() {
+        return WeslExecResult {
+            success: false,
+            resources: ptr::null(),
+            error: WeslError {
+                source: ptr::null(),
+                message: create_c_string("Invalid parameters"),
+                diagnostics: ptr::null(),
+                diagnostics_len: 0,
+            },
+        };
+    }
+
+    let files_map = unsafe { string_map_to_hashmap(files) };
+    let root_str = unsafe { CStr::from_ptr(root).to_string_lossy() };
+    let entrypoint_str = unsafe { CStr::from_ptr(entrypoint).to_string_lossy() };
+    let opts = unsafe { &*options };
+    let resources_vec = unsafe { binding_array_to_vec(resources) };
+    let overrides_map = unsafe { string_map_to_hashmap(overrides) };
+    let features_map = unsafe { bool_map_to_hashmap(features) };
+
+    let root_path = match root_str.parse() {
+        Ok(path) => path,
+        Err(e) => {
+            return WeslExecResult {
+                success: false,
+                resources: ptr::null(),
+                error: WeslError {
+                    source: ptr::null(),
+                    message: create_c_string(&format!("Invalid root path: {}", e)),
+                    diagnostics: ptr::null(),
+                    diagnostics_len: 0,
+                },
+            };
+        }
+    };
+
+    let mut resolver = VirtualResolver::new();
+    for (path, source) in files_map {
+        if let Ok(module_path) = path.parse() {
+            resolver.add_module(module_path, source.into());
+        }
+    }
+
+    let mut compiler = Wesl::new_barebones().set_custom_resolver(resolver);
+    let compiler = compiler
+        .set_options(wesl::CompileOptions {
+            imports: opts.imports,
+            condcomp: opts.condcomp,
+            generics: opts.generics,
+            strip: opts.strip,
+            lower: opts.lower,
+            validate: opts.validate,
+            lazy: opts.lazy,
+            mangle_root: opts.mangle_root,
+            keep: None,
+            features: wesl::Features {
+                default: wesl::Feature::Disable,
+                flags: features_map
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into()))
+                    .collect(),
+            },
+            keep_root: opts.keep_root,
+        })
+        .use_sourcemap(opts.sourcemap)
+        .set_mangler(opts.mangler.into());
+
+    match compiler.compile(&root_path) {
+        Ok(result) => {
+            // parse resources
+            let parsed_resources: Result<HashMap<(u32, u32), RefInstance>, wesl::Error> =
+                resources_vec
+                    .iter()
+                    .map(|r| parse_c_binding(r, &result.syntax))
+                    .collect();
+
+            let parsed_resources = match parsed_resources {
+                Ok(resources) => resources,
+                Err(e) => {
+                    return WeslExecResult {
+                        success: false,
+                        resources: ptr::null(),
+                        error: wesl_error_to_c(e),
+                    };
+                }
+            };
+
+            // parse overrides
+            let parsed_overrides: Result<HashMap<String, Instance>, wesl::Error> = overrides_map
+                .iter()
+                .map(|(name, expr)| {
+                    let mut ctx = wesl::eval::Context::new(&result.syntax);
+                    let expr = expr.parse::<wesl::syntax::Expression>().map_err(|e| {
+                        wesl::Error::Custom(format!("Failed to parse override expression: {}", e))
+                    })?;
+                    let inst = expr.eval_value(&mut ctx).map_err(|e| {
+                        wesl::Error::Custom(format!("Failed to evaluate override: {}", e))
+                    })?;
+                    Ok((name.clone(), inst))
+                })
+                .collect();
+
+            let parsed_overrides = match parsed_overrides {
+                Ok(overrides) => overrides,
+                Err(e) => {
+                    return WeslExecResult {
+                        success: false,
+                        resources: ptr::null(),
+                        error: wesl_error_to_c(e),
+                    };
+                }
+            };
+
+            // execute
+            let inputs = Inputs::new_zero_initialized();
+            match result.exec(&entrypoint_str, inputs, parsed_resources, parsed_overrides) {
+                Ok(mut exec_result) => {
+                    // convert resources back to C format
+                    let output_resources: Vec<WeslBinding> = resources_vec
+                        .iter()
+                        .filter_map(|r| {
+                            let resource = exec_result.resource(r.group, r.binding)?;
+                            let inst = resource.read().ok()?.to_owned();
+                            let mut new_binding = *r;
+                            if let Some(buffer) = inst.to_buffer(&mut exec_result.ctx) {
+                                let boxed_data = buffer.into_boxed_slice();
+                                new_binding.data_len = boxed_data.len();
+                                new_binding.data = Box::into_raw(boxed_data) as *const u8;
+                            }
+                            Some(new_binding)
+                        })
+                        .collect();
+
+                    WeslExecResult {
+                        success: true,
+                        resources: create_c_binding_array(output_resources),
+                        error: WeslError {
+                            source: ptr::null(),
+                            message: ptr::null(),
+                            diagnostics: ptr::null(),
+                            diagnostics_len: 0,
+                        },
+                    }
+                }
+                Err(e) => WeslExecResult {
+                    success: false,
+                    resources: ptr::null(),
+                    error: wesl_error_to_c(e),
+                },
+            }
+        }
+        Err(e) => WeslExecResult {
+            success: false,
+            resources: ptr::null(),
+            error: wesl_error_to_c(e),
+        },
+    }
+}
+
+#[cfg(not(feature = "eval"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_exec(
+    _files: *const WeslStringMap,
+    _root: *const c_char,
+    _entrypoint: *const c_char,
+    _options: *const WeslCompileOptions,
+    _resources: *const WeslBindingArray,
+    _overrides: *const WeslStringMap,
+    _features: *const WeslBoolMap,
+) -> WeslExecResult {
+    WeslExecResult {
+        success: false,
+        resources: ptr::null(),
+        error: WeslError {
+            source: ptr::null(),
+            message: create_c_string("wesl_exec requires the 'eval' feature to be enabled"),
+            diagnostics: ptr::null(),
+            diagnostics_len: 0,
+        },
+    }
+}
+
 // -- memory
 
 #[unsafe(no_mangle)]
@@ -502,6 +837,56 @@ pub unsafe extern "C" fn wesl_free_result(result: *mut WeslResult) {
 pub unsafe extern "C" fn wesl_free_compile_result(result: *mut WeslCompileResult) {
     if !result.is_null() {
         let _ = unsafe { Box::from_raw(result) };
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_free_exec_result(result: *mut WeslExecResult) {
+    if !result.is_null() {
+        unsafe {
+            let result = &mut *result;
+
+            if !result.resources.is_null() {
+                let resources = &*result.resources;
+
+                // free each binding
+                for i in 0..resources.len {
+                    let binding = *resources.items.add(i);
+                    if !binding.data.is_null() {
+                        let _ = Box::from_raw(std::slice::from_raw_parts_mut(
+                            binding.data as *mut u8,
+                            binding.data_len,
+                        ));
+                    }
+                }
+
+                let _ = Box::from_raw(std::slice::from_raw_parts_mut(
+                    resources.items as *mut WeslBinding,
+                    resources.len,
+                ));
+
+                let _ = Box::from_raw(result.resources as *mut WeslBindingArray);
+            }
+
+            if !result.error.source.is_null() {
+                wesl_free_string(result.error.source);
+            }
+
+            if !result.error.message.is_null() {
+                wesl_free_string(result.error.message);
+            }
+
+            if !result.error.diagnostics.is_null() {
+                let diag = &*result.error.diagnostics;
+                if !diag.file.is_null() {
+                    wesl_free_string(diag.file);
+                }
+                if !diag.title.is_null() {
+                    wesl_free_string(diag.title);
+                }
+                let _ = Box::from_raw(result.error.diagnostics as *mut WeslDiagnostic);
+            }
+        }
     }
 }
 

--- a/crates/wesl-c/src/lib.rs
+++ b/crates/wesl-c/src/lib.rs
@@ -147,11 +147,6 @@ pub struct WeslCompiler {
     compiler: Box<dyn std::any::Any + Send + Sync>,
 }
 
-#[repr(C)]
-pub struct WeslCompileResult {
-    result: CompileResult,
-}
-
 // -- helpers
 
 unsafe fn string_map_to_hashmap(map: *const WeslStringMap) -> HashMap<String, String> {
@@ -832,13 +827,6 @@ pub unsafe extern "C" fn wesl_free_result(result: *mut WeslResult) {
                 let _ = Box::from_raw(result.error.diagnostics as *mut WeslDiagnostic);
             }
         }
-    }
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn wesl_free_compile_result(result: *mut WeslCompileResult) {
-    if !result.is_null() {
-        let _ = unsafe { Box::from_raw(result) };
     }
 }
 

--- a/crates/wesl-c/src/lib.rs
+++ b/crates/wesl-c/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_safety_doc)]
+
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_uint};
@@ -243,8 +245,8 @@ fn wesl_error_to_c(e: wesl::Error) -> WeslError {
         };
 
         let boxed = Box::new(diag);
-        let ptr = Box::into_raw(boxed);
-        ptr
+
+        Box::into_raw(boxed)
     } else {
         ptr::null()
     };
@@ -896,5 +898,5 @@ pub unsafe extern "C" fn wesl_free_exec_result(result: *mut WeslExecResult) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wesl_version() -> *const c_char {
     const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "\0");
-    return VERSION.as_ptr() as *const c_char;
+    VERSION.as_ptr() as *const c_char
 }

--- a/crates/wesl-c/src/lib.rs
+++ b/crates/wesl-c/src/lib.rs
@@ -5,7 +5,7 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_uint};
 use std::ptr;
 
-use wesl::{CompileResult, VirtualResolver, Wesl};
+use wesl::{VirtualResolver, Wesl};
 
 #[cfg(feature = "eval")]
 use wesl::{

--- a/crates/wesl-c/src/lib.rs
+++ b/crates/wesl-c/src/lib.rs
@@ -310,7 +310,7 @@ fn parse_c_binding(
         })?;
 
     let ty = wesl::eval::ty_eval_ty(&ty_expr, &mut ctx)
-        .map_err(|e| wesl::Error::Custom(format!("Failed to evaluate type: {}", e)))?;
+        .map_err(|e| wesl::Error::Custom(format!("Failed to evaluate type: {e}")))?;
 
     let (storage, access) = match b.kind {
         WeslBindingType::Uniform => (AddressSpace::Uniform, AccessMode::Read),
@@ -412,7 +412,7 @@ pub unsafe extern "C" fn wesl_compile(
                 data: ptr::null(),
                 error: WeslError {
                     source: ptr::null(),
-                    message: create_c_string(&format!("Invalid root path: {}", e)),
+                    message: create_c_string(&format!("Invalid root path: {e}")),
                     diagnostics: ptr::null(),
                     diagnostics_len: 0,
                 },
@@ -509,7 +509,7 @@ pub unsafe extern "C" fn wesl_eval(
                 data: ptr::null(),
                 error: WeslError {
                     source: ptr::null(),
-                    message: create_c_string(&format!("Invalid root path: {}", e)),
+                    message: create_c_string(&format!("Invalid root path: {e}")),
                     diagnostics: ptr::null(),
                     diagnostics_len: 0,
                 },
@@ -635,7 +635,7 @@ pub unsafe extern "C" fn wesl_exec(
                 resources: ptr::null(),
                 error: WeslError {
                     source: ptr::null(),
-                    message: create_c_string(&format!("Invalid root path: {}", e)),
+                    message: create_c_string(&format!("Invalid root path: {e}")),
                     diagnostics: ptr::null(),
                     diagnostics_len: 0,
                 },
@@ -700,10 +700,10 @@ pub unsafe extern "C" fn wesl_exec(
                 .map(|(name, expr)| {
                     let mut ctx = wesl::eval::Context::new(&result.syntax);
                     let expr = expr.parse::<wesl::syntax::Expression>().map_err(|e| {
-                        wesl::Error::Custom(format!("Failed to parse override expression: {}", e))
+                        wesl::Error::Custom(format!("Failed to parse override expression: {e}"))
                     })?;
                     let inst = expr.eval_value(&mut ctx).map_err(|e| {
-                        wesl::Error::Custom(format!("Failed to evaluate override: {}", e))
+                        wesl::Error::Custom(format!("Failed to evaluate override: {e}"))
                     })?;
                     Ok((name.clone(), inst))
                 })

--- a/crates/wesl-c/src/lib.rs
+++ b/crates/wesl-c/src/lib.rs
@@ -1,0 +1,513 @@
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_uint};
+use std::ptr;
+
+use wesl::{CompileResult, VirtualResolver, Wesl};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub enum WeslManglerKind {
+    Escape = 0,
+    Hash = 1,
+    None = 2,
+}
+
+impl From<WeslManglerKind> for wesl::ManglerKind {
+    fn from(value: WeslManglerKind) -> Self {
+        match value {
+            WeslManglerKind::Escape => wesl::ManglerKind::Escape,
+            WeslManglerKind::Hash => wesl::ManglerKind::Hash,
+            WeslManglerKind::None => wesl::ManglerKind::None,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub enum WeslBindingType {
+    Uniform = 0,
+    Storage = 1,
+    ReadOnlyStorage = 2,
+    Filtering = 3,
+    NonFiltering = 4,
+    Comparison = 5,
+    Float = 6,
+    UnfilterableFloat = 7,
+    Sint = 8,
+    Uint = 9,
+    Depth = 10,
+    WriteOnly = 11,
+    ReadWrite = 12,
+    ReadOnly = 13,
+}
+
+#[repr(C)]
+pub struct WeslBinding {
+    pub group: c_uint,
+    pub binding: c_uint,
+    pub kind: WeslBindingType,
+    pub data: *const u8,
+    pub data_len: usize,
+}
+
+#[repr(C)]
+pub struct WeslCompileOptions {
+    pub mangler: WeslManglerKind,
+    pub sourcemap: bool,
+    pub imports: bool,
+    pub condcomp: bool,
+    pub generics: bool,
+    pub strip: bool,
+    pub lower: bool,
+    pub validate: bool,
+    pub naga: bool,
+    pub lazy: bool,
+    pub keep_root: bool,
+    pub mangle_root: bool,
+}
+
+#[repr(C)]
+pub struct WeslStringMap {
+    pub keys: *const *const c_char,
+    pub values: *const *const c_char,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct WeslBoolMap {
+    pub keys: *const *const c_char,
+    pub values: *const bool,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct WeslStringArray {
+    pub items: *const *const c_char,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct WeslBindingArray {
+    pub items: *const WeslBinding,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct WeslDiagnostic {
+    pub file: *const c_char,
+    pub span_start: c_uint,
+    pub span_end: c_uint,
+    pub title: *const c_char,
+}
+
+#[repr(C)]
+pub struct WeslError {
+    pub source: *const c_char,
+    pub message: *const c_char,
+    pub diagnostics: *const WeslDiagnostic,
+    pub diagnostics_len: usize,
+}
+
+#[repr(C)]
+pub struct WeslResult {
+    pub success: bool,
+    pub data: *const c_char,
+    pub error: WeslError,
+}
+
+// -- handles
+
+#[repr(C)]
+pub struct WeslCompiler {
+    compiler: Box<dyn std::any::Any + Send + Sync>,
+}
+
+#[repr(C)]
+pub struct WeslCompileResult {
+    result: CompileResult,
+}
+
+// -- helpers
+
+unsafe fn string_map_to_hashmap(map: *const WeslStringMap) -> HashMap<String, String> {
+    if map.is_null() {
+        return HashMap::new();
+    }
+
+    unsafe {
+        let map = &*map;
+        let mut result = HashMap::new();
+
+        for i in 0..map.len {
+            let key_ptr = *map.keys.add(i);
+            let value_ptr = *map.values.add(i);
+
+            if !key_ptr.is_null() && !value_ptr.is_null() {
+                let key = CStr::from_ptr(key_ptr).to_string_lossy().into_owned();
+                let value = CStr::from_ptr(value_ptr).to_string_lossy().into_owned();
+                result.insert(key, value);
+            }
+        }
+
+        result
+    }
+}
+
+unsafe fn bool_map_to_hashmap(map: *const WeslBoolMap) -> HashMap<String, bool> {
+    if map.is_null() {
+        return HashMap::new();
+    }
+
+    unsafe {
+        let map = &*map;
+        let mut result = HashMap::new();
+
+        for i in 0..map.len {
+            let key_ptr = *map.keys.add(i);
+            let value = *map.values.add(i);
+
+            if !key_ptr.is_null() {
+                let key = CStr::from_ptr(key_ptr).to_string_lossy().into_owned();
+                result.insert(key, value);
+            }
+        }
+
+        result
+    }
+}
+
+unsafe fn string_array_to_vec(array: *const WeslStringArray) -> Option<Vec<String>> {
+    if array.is_null() {
+        return None;
+    }
+
+    unsafe {
+        let array = &*array;
+        let mut result = Vec::new();
+
+        for i in 0..array.len {
+            let item_ptr = *array.items.add(i);
+            if !item_ptr.is_null() {
+                let item = CStr::from_ptr(item_ptr).to_string_lossy().into_owned();
+                result.push(item);
+            }
+        }
+
+        Some(result)
+    }
+}
+
+fn create_c_string(s: &str) -> *const c_char {
+    match CString::new(s) {
+        Ok(c_str) => {
+            let ptr = c_str.as_ptr();
+            std::mem::forget(c_str);
+            ptr
+        }
+        Err(_) => ptr::null(),
+    }
+}
+
+fn wesl_error_to_c(e: wesl::Error) -> WeslError {
+    let d = wesl::Diagnostic::from(e);
+
+    let diagnostics = if let (Some(span), Some(res)) = (&d.detail.span, &d.detail.module_path) {
+        let diag = WeslDiagnostic {
+            file: create_c_string(&res.components.join("/")),
+            span_start: span.start as u32,
+            span_end: span.end as u32,
+            title: create_c_string(&d.error.to_string()),
+        };
+
+        let boxed = Box::new(diag);
+        let ptr = Box::into_raw(boxed);
+        ptr
+    } else {
+        ptr::null()
+    };
+
+    WeslError {
+        source: d
+            .detail
+            .output
+            .as_ref()
+            .map_or(ptr::null(), |s| create_c_string(s)),
+        message: create_c_string(&d.to_string()),
+        diagnostics,
+        diagnostics_len: if diagnostics.is_null() {
+            0
+        } else {
+            1
+        },
+    }
+}
+
+// -- main API
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_create_compiler() -> *mut WeslCompiler {
+    let compiler = Wesl::new_barebones();
+    let boxed = Box::new(WeslCompiler {
+        compiler: Box::new(compiler),
+    });
+    Box::into_raw(boxed)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_destroy_compiler(compiler: *mut WeslCompiler) {
+    if !compiler.is_null() {
+        let _ = unsafe { Box::from_raw(compiler) };
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_compile(
+    files: *const WeslStringMap,
+    root: *const c_char,
+    options: *const WeslCompileOptions,
+    keep: *const WeslStringArray,
+    features: *const WeslBoolMap,
+) -> WeslResult {
+    if files.is_null() || root.is_null() || options.is_null() {
+        return WeslResult {
+            success: false,
+            data: ptr::null(),
+            error: WeslError {
+                source: ptr::null(),
+                message: create_c_string("Invalid parameters"),
+                diagnostics: ptr::null(),
+                diagnostics_len: 0,
+            },
+        };
+    }
+
+    let files_map = unsafe { string_map_to_hashmap(files) };
+    let root_str = unsafe { CStr::from_ptr(root).to_string_lossy() };
+    let opts = unsafe { &*options };
+    let keep_vec = unsafe { string_array_to_vec(keep) };
+    let features_map = unsafe { bool_map_to_hashmap(features) };
+
+    let root_path = match root_str.parse() {
+        Ok(path) => path,
+        Err(e) => {
+            return WeslResult {
+                success: false,
+                data: ptr::null(),
+                error: WeslError {
+                    source: ptr::null(),
+                    message: create_c_string(&format!("Invalid root path: {}", e)),
+                    diagnostics: ptr::null(),
+                    diagnostics_len: 0,
+                },
+            };
+        }
+    };
+
+    let mut resolver = VirtualResolver::new();
+    for (path, source) in files_map {
+        if let Ok(module_path) = path.parse() {
+            resolver.add_module(module_path, source.into());
+        }
+    }
+
+    let mut compiler = Wesl::new_barebones().set_custom_resolver(resolver);
+    let compiler = compiler
+        .set_options(wesl::CompileOptions {
+            imports: opts.imports,
+            condcomp: opts.condcomp,
+            generics: opts.generics,
+            strip: opts.strip,
+            lower: opts.lower,
+            validate: opts.validate,
+            lazy: opts.lazy,
+            mangle_root: opts.mangle_root,
+            keep: keep_vec,
+            features: wesl::Features {
+                default: wesl::Feature::Disable,
+                flags: features_map
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into()))
+                    .collect(),
+            },
+            keep_root: opts.keep_root,
+        })
+        .use_sourcemap(opts.sourcemap)
+        .set_mangler(opts.mangler.into());
+
+    match compiler.compile(&root_path) {
+        Ok(result) => {
+            let output = result.to_string();
+            WeslResult {
+                success: true,
+                data: create_c_string(&output),
+                error: WeslError {
+                    source: ptr::null(),
+                    message: ptr::null(),
+                    diagnostics: ptr::null(),
+                    diagnostics_len: 0,
+                },
+            }
+        }
+        Err(e) => WeslResult {
+            success: false,
+            data: ptr::null(),
+            error: wesl_error_to_c(e),
+        },
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_eval(
+    files: *const WeslStringMap,
+    root: *const c_char,
+    expression: *const c_char,
+    options: *const WeslCompileOptions,
+    features: *const WeslBoolMap,
+) -> WeslResult {
+    if files.is_null() || root.is_null() || expression.is_null() || options.is_null() {
+        return WeslResult {
+            success: false,
+            data: ptr::null(),
+            error: WeslError {
+                source: ptr::null(),
+                message: create_c_string("Invalid parameters"),
+                diagnostics: ptr::null(),
+                diagnostics_len: 0,
+            },
+        };
+    }
+
+    let files_map = unsafe { string_map_to_hashmap(files) };
+    let root_str = unsafe { CStr::from_ptr(root).to_string_lossy() };
+    let expr_str = unsafe { CStr::from_ptr(expression).to_string_lossy() };
+    let opts = unsafe { &*options };
+    let features_map = unsafe { bool_map_to_hashmap(features) };
+
+    let root_path = match root_str.parse() {
+        Ok(path) => path,
+        Err(e) => {
+            return WeslResult {
+                success: false,
+                data: ptr::null(),
+                error: WeslError {
+                    source: ptr::null(),
+                    message: create_c_string(&format!("Invalid root path: {}", e)),
+                    diagnostics: ptr::null(),
+                    diagnostics_len: 0,
+                },
+            };
+        }
+    };
+
+    let mut resolver = VirtualResolver::new();
+    for (path, source) in files_map {
+        if let Ok(module_path) = path.parse() {
+            resolver.add_module(module_path, source.into());
+        }
+    }
+
+    let mut compiler = Wesl::new_barebones().set_custom_resolver(resolver);
+    let compiler = compiler
+        .set_options(wesl::CompileOptions {
+            imports: opts.imports,
+            condcomp: opts.condcomp,
+            generics: opts.generics,
+            strip: opts.strip,
+            lower: opts.lower,
+            validate: opts.validate,
+            lazy: opts.lazy,
+            mangle_root: opts.mangle_root,
+            keep: None,
+            features: wesl::Features {
+                default: wesl::Feature::Disable,
+                flags: features_map
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into()))
+                    .collect(),
+            },
+            keep_root: opts.keep_root,
+        })
+        .use_sourcemap(opts.sourcemap)
+        .set_mangler(opts.mangler.into());
+
+    match compiler.compile(&root_path) {
+        Ok(result) => match result.eval(&expr_str) {
+            Ok(eval_result) => WeslResult {
+                success: true,
+                data: create_c_string(&eval_result.inst.to_string()),
+                error: WeslError {
+                    source: ptr::null(),
+                    message: ptr::null(),
+                    diagnostics: ptr::null(),
+                    diagnostics_len: 0,
+                },
+            },
+            Err(e) => WeslResult {
+                success: false,
+                data: ptr::null(),
+                error: wesl_error_to_c(e),
+            },
+        },
+        Err(e) => WeslResult {
+            success: false,
+            data: ptr::null(),
+            error: wesl_error_to_c(e),
+        },
+    }
+}
+
+// -- memory
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_free_string(ptr: *const c_char) {
+    if !ptr.is_null() {
+        let _ = unsafe { CString::from_raw(ptr as *mut c_char) };
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_free_result(result: *mut WeslResult) {
+    if !result.is_null() {
+        unsafe {
+            let result = &mut *result;
+
+            if !result.data.is_null() {
+                wesl_free_string(result.data);
+            }
+
+            if !result.error.source.is_null() {
+                wesl_free_string(result.error.source);
+            }
+
+            if !result.error.message.is_null() {
+                wesl_free_string(result.error.message);
+            }
+
+            if !result.error.diagnostics.is_null() {
+                let diag = &*result.error.diagnostics;
+                if !diag.file.is_null() {
+                    wesl_free_string(diag.file);
+                }
+                if !diag.title.is_null() {
+                    wesl_free_string(diag.title);
+                }
+                let _ = Box::from_raw(result.error.diagnostics as *mut WeslDiagnostic);
+            }
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_free_compile_result(result: *mut WeslCompileResult) {
+    if !result.is_null() {
+        let _ = unsafe { Box::from_raw(result) };
+    }
+}
+
+// -- utility
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wesl_version() -> *const c_char {
+    create_c_string(env!("CARGO_PKG_VERSION"))
+}


### PR DESCRIPTION
This PR adds C bindings for the wesl-rs compiler.

API example:
```c
int main() {
    // print version
    const char* version = wesl_version();
    printf("WESL version: %s\n", version);
    wesl_free_string(version);

    // add some modules
    const char* modules[] = {
        "package::main",
        "package::utils"
    };

    const char* sources[] = {
        "import package::utils::add;\nfn some_fn_in_main() -> i32 { let a = add(1, 2); return a; } ",
        "fn add(a: i32, b: i32) -> i32 { return a + b; } "
    };

    // file map
    WeslStringMap file_map = create_string_map(modules, sources, 2);

    // setup compile options
    WeslCompileOptions options = {
        .mangler = WESL_MANGLER_NONE,
        .sourcemap = true,
        .imports = true,
        .condcomp = true,
        .generics = true,
        .strip = false,
        .lower = true,
        .validate = true,
        .naga = true,
        .lazy = false,
        .keep_root = true,
        .mangle_root = false
    };

    // setup features
    const char* feature_keys[] = {"debug"};
    bool feature_values[] = {true};
    WeslBoolMap features = create_bool_map(feature_keys, feature_values, 1);

    // compile
    printf("calling wesl_compile...\n");
    WeslResult result = wesl_compile(
        &file_map,
        "package::main",
        &options,
        NULL,   // omit keep array
        &features
    );
    // ...
    return 0;
}
```

See full example in `crates/wesl-c/examples/simple.c`