### PR TITLE
Add Type::Ref to wgsl-types

### DIFF
--- a/crates/wesl/src/error.rs
+++ b/crates/wesl/src/error.rs
@@ -331,6 +331,7 @@ impl Diagnostic<Error> {
                 Type::Array(ty, _) => unmangle_ty(&mut *ty, sourcemap, mangler),
                 Type::Atomic(ty) => unmangle_ty(&mut *ty, sourcemap, mangler),
                 Type::Ptr(_, ty, _) => unmangle_ty(&mut *ty, sourcemap, mangler),
+                Type::Ref(_, ty, _) => unmangle_ty(&mut *ty, sourcemap, mangler),
                 _ => (),
             }
         }

--- a/crates/wesl/src/eval/attrs.rs
+++ b/crates/wesl/src/eval/attrs.rs
@@ -1,11 +1,11 @@
+use wgsl_parse::{
+    Decorated,
+    syntax::{Attribute, AttributeNode, BuiltinValue, Expression},
+};
 use wgsl_types::{
     ShaderStage,
     inst::{Instance, LiteralInstance},
     ty::{Ty, Type},
-};
-use wgsl_parse::{
-    Decorated,
-    syntax::{Attribute, AttributeNode, BuiltinValue, Expression},
 };
 
 use super::{Context, Eval, EvalError, with_stage};

--- a/crates/wesl/src/eval/attrs.rs
+++ b/crates/wesl/src/eval/attrs.rs
@@ -44,20 +44,20 @@ pub trait EvalAttrs: Decorated {
 
 impl<T: Decorated> EvalAttrs for T {}
 fn eval_positive_integer(expr: &Expression, ctx: &mut Context) -> Result<u32, E> {
-    let expr = with_stage!(ctx, ShaderStage::Const, { expr.eval_value(ctx) })?;
-    let expr = match expr {
+    let inst = with_stage!(ctx, ShaderStage::Const, { expr.eval_value(ctx) })?;
+    let integer = match inst {
         Instance::Literal(g) => match g {
             LiteralInstance::AbstractInt(g) => Ok(g),
             LiteralInstance::I32(g) => Ok(g as i64),
             LiteralInstance::U32(g) => Ok(g as i64),
             _ => Err(E::Type(Type::U32, g.ty())),
         },
-        _ => Err(E::Type(Type::U32, expr.ty())),
+        _ => Err(E::Type(Type::U32, inst.ty())),
     }?;
-    if expr < 0 {
-        Err(E::NegativeAttr(expr))
+    if integer < 0 {
+        Err(E::NegativeAttr(integer))
     } else {
-        Ok(expr as u32)
+        Ok(integer as u32)
     }
 }
 

--- a/crates/wesl/src/eval/builtin.rs
+++ b/crates/wesl/src/eval/builtin.rs
@@ -1,8 +1,8 @@
 use std::sync::LazyLock;
 
 use wesl_macros::{quote_expression, quote_module};
-use wgsl_types::ty::{SampledType, SamplerType, TextureType, Type};
 use wgsl_parse::syntax::*;
+use wgsl_types::ty::{SampledType, SamplerType, TextureType, Type};
 
 use crate::builtin::builtin_ident;
 
@@ -59,6 +59,7 @@ impl BuiltinIdent for Type {
             },
             Type::Atomic(_) => builtin_ident("atomic"),
             Type::Ptr(_, _, _) => builtin_ident("ptr"),
+            Type::Ref(_, _, _) => builtin_ident("__ref"),
             Type::Texture(texture_type) => texture_type.builtin_ident(),
             Type::Sampler(sampler_type) => sampler_type.builtin_ident(),
         }

--- a/crates/wesl/src/eval/constant.rs
+++ b/crates/wesl/src/eval/constant.rs
@@ -1,7 +1,7 @@
 use super::{Scope, SyntaxUtil};
 use itertools::Itertools;
-use wgsl_types::builtin::is_constructor_fn;
 use wgsl_parse::{Decorated, span::Spanned, syntax::*};
+use wgsl_types::builtin::is_constructor_fn;
 
 macro_rules! with_scope {
     ($scope:expr, $body:tt) => {{

--- a/crates/wesl/src/eval/eval.rs
+++ b/crates/wesl/src/eval/eval.rs
@@ -14,11 +14,7 @@ pub trait Eval {
     fn eval(&self, ctx: &mut Context) -> Result<Instance, E>;
 
     fn eval_value(&self, ctx: &mut Context) -> Result<Instance, E> {
-        let mut inst = self.eval(ctx)?;
-        while let Instance::Ref(r) = inst {
-            inst = r.read()?.to_owned();
-        }
-        Ok(inst)
+        Ok(self.eval(ctx)?.loaded()?)
     }
 }
 
@@ -33,11 +29,6 @@ impl<T: Eval> Eval for Spanned<T> {
     fn eval(&self, ctx: &mut Context) -> Result<Instance, E> {
         self.node()
             .eval(ctx)
-            .inspect_err(|_| ctx.set_err_span_ctx(self.span()))
-    }
-    fn eval_value(&self, ctx: &mut Context) -> Result<Instance, E> {
-        self.node()
-            .eval_value(ctx)
             .inspect_err(|_| ctx.set_err_span_ctx(self.span()))
     }
 }

--- a/crates/wesl/src/eval/eval.rs
+++ b/crates/wesl/src/eval/eval.rs
@@ -1,10 +1,10 @@
 use half::f16;
 use itertools::Itertools;
+use wgsl_parse::{span::Spanned, syntax::*};
 use wgsl_types::{
     inst::{Instance, LiteralInstance, PtrInstance, RefInstance, VecInstance},
     ty::{Ty, Type},
 };
-use wgsl_parse::{span::Spanned, syntax::*};
 
 use super::{Context, EvalError, Exec, Flow, ScopeKind, SyntaxUtil};
 

--- a/crates/wesl/src/eval/exec.rs
+++ b/crates/wesl/src/eval/exec.rs
@@ -209,7 +209,6 @@ impl Exec for AssignmentStatement {
             let rhs = self.rhs.eval_value(ctx)?;
             match self.operator {
                 AssignmentOperator::Equal => {
-                    // Assumption: rhs type is concrete
                     let rhs = rhs
                         .convert_to(&r.ty)
                         .ok_or_else(|| E::AssignType(rhs.ty(), r.ty.clone()))?;

--- a/crates/wesl/src/eval/exec.rs
+++ b/crates/wesl/src/eval/exec.rs
@@ -209,6 +209,7 @@ impl Exec for AssignmentStatement {
             let rhs = self.rhs.eval_value(ctx)?;
             match self.operator {
                 AssignmentOperator::Equal => {
+                    // Assumption: rhs type is concrete
                     let rhs = rhs
                         .convert_to(&r.ty)
                         .ok_or_else(|| E::AssignType(rhs.ty(), r.ty.clone()))?;

--- a/crates/wesl/src/eval/exec.rs
+++ b/crates/wesl/src/eval/exec.rs
@@ -206,15 +206,12 @@ impl Exec for AssignmentStatement {
         let lhs = self.lhs.eval(ctx)?;
 
         if let Instance::Ref(r) = lhs {
-            // TODO: ty must be concrete, so this should just be a is_concrete check https://www.w3.org/TR/WGSL/#simple-assignment-section
-            let ty = r.ty.concretize();
-
             let rhs = self.rhs.eval_value(ctx)?;
             match self.operator {
                 AssignmentOperator::Equal => {
                     let rhs = rhs
-                        .convert_to(&ty)
-                        .ok_or_else(|| E::AssignType(rhs.ty(), ty))?;
+                        .convert_to(&r.ty)
+                        .ok_or_else(|| E::AssignType(rhs.ty(), r.ty.clone()))?;
                     r.write(rhs)?;
                 }
                 AssignmentOperator::PlusEqual => {

--- a/crates/wesl/src/eval/exec.rs
+++ b/crates/wesl/src/eval/exec.rs
@@ -1,19 +1,19 @@
 use std::{collections::HashMap, fmt::Display, iter::zip};
 use wgsl_types::{
+    ShaderStage,
     builtin::{call_builtin, is_constructor_fn},
     conv::Convert,
     enums::{AccessMode, AddressSpace},
     inst::{Instance, LiteralInstance, RefInstance, StructInstance, VecInstance},
     ty::{StructMemberType, StructType, Ty, Type},
-    ShaderStage,
 };
 
 use super::{
-    attrs::EvalAttrs, eval_tplt_arg, ty_eval_ty, Context, Eval, EvalError, EvalTy, ScopeKind,
-    SyntaxUtil, ATTR_INTRINSIC,
+    ATTR_INTRINSIC, Context, Eval, EvalError, EvalTy, ScopeKind, SyntaxUtil, attrs::EvalAttrs,
+    eval_tplt_arg, ty_eval_ty,
 };
 
-use wgsl_parse::{span::Spanned, syntax::*, Decorated};
+use wgsl_parse::{Decorated, span::Spanned, syntax::*};
 
 type E = EvalError;
 

--- a/crates/wesl/src/eval/exec.rs
+++ b/crates/wesl/src/eval/exec.rs
@@ -204,9 +204,11 @@ impl Exec for AssignmentStatement {
         }
 
         let lhs = self.lhs.eval(ctx)?;
-        let ty = lhs.ty().concretize();
 
         if let Instance::Ref(r) = lhs {
+            // TODO: ty must be concrete, so this should just be a is_concrete check https://www.w3.org/TR/WGSL/#simple-assignment-section
+            let ty = r.ty.concretize();
+
             let rhs = self.rhs.eval_value(ctx)?;
             match self.operator {
                 AssignmentOperator::Equal => {
@@ -986,8 +988,8 @@ impl Exec for Declaration {
                             let inst = ctx
                                 .resource(group, binding)
                                 .ok_or(E::MissingResource(group, binding))?;
-                            if inst.ty() != ty {
-                                return Err(E::Type(ty, inst.ty()));
+                            if inst.ty != ty {
+                                return Err(E::Type(ty, inst.ty.clone()));
                             }
                             if !inst.space.is_uniform() {
                                 return Err(E::AddressSpace(a_s, inst.space));
@@ -1009,8 +1011,8 @@ impl Exec for Declaration {
                             let inst = ctx
                                 .resource(group, binding)
                                 .ok_or(E::MissingResource(group, binding))?;
-                            if ty != inst.ty() {
-                                return Err(E::Type(ty, inst.ty()));
+                            if ty != inst.ty {
+                                return Err(E::Type(ty, inst.ty.clone()));
                             }
                             if !inst.space.is_storage() {
                                 return Err(E::AddressSpace(a_s, inst.space));

--- a/crates/wesl/src/eval/lower.rs
+++ b/crates/wesl/src/eval/lower.rs
@@ -1,6 +1,6 @@
 use std::iter::zip;
 use wgsl_parse::{Decorated, span::Spanned, syntax::*};
-use wgsl_types::ty::Ty;
+use wgsl_types::ty::{Ty, Type};
 
 use crate::eval::{ATTR_INTRINSIC, Context, Eval, EvalError, Exec, ty_eval_ty};
 
@@ -20,7 +20,7 @@ fn make_explicit_call(call: &mut FunctionCall, ctx: &mut Context) -> Result<(), 
         }
 
         for (arg, param) in zip(&mut call.arguments, &decl.parameters) {
-            let arg_ty = arg.eval_ty(ctx)?;
+            let arg_ty = arg.eval_ty(ctx)?.loaded();
             let param_ty = ty_eval_ty(&param.ty, ctx)?;
             if arg_ty != param_ty {
                 if arg_ty.is_convertible_to(&param_ty) {
@@ -59,7 +59,7 @@ fn make_explicit_return(stmt: &mut ReturnStatement, ctx: &mut Context) -> Result
         }
         (Some(expr), Some(ret_expr)) => {
             let ret_ty = ty_eval_ty(ret_expr, ctx)?;
-            let expr_ty = expr.eval_ty(ctx)?;
+            let expr_ty = expr.eval_ty(ctx)?.loaded();
             if expr_ty != ret_ty {
                 if expr_ty.is_convertible_to(&ret_ty) {
                     let ty = ret_ty.to_expr(ctx)?.unwrap_type_or_identifier();
@@ -207,7 +207,7 @@ impl Lower for Declaration {
         let ty = match (&self.ty, &self.initializer) {
             (None, None) => return Err(E::UntypedDecl),
             (None, Some(init)) => {
-                let ty = init.eval_ty(ctx)?;
+                let ty = init.eval_ty(ctx)?.loaded();
                 if self.kind.is_const() {
                     ty // only const declarations can be of abstract type.
                 } else {
@@ -221,9 +221,20 @@ impl Lower for Declaration {
             self.ty = Some(ty.to_expr(ctx)?.unwrap_type_or_identifier());
         }
 
+        let inst_ty = if let DeclarationKind::Var(as_am) = self.kind {
+            let (a_s, a_m) = match as_am {
+                Some((a_s, Some(a_m))) => (a_s, a_m),
+                Some((a_s, None)) => (a_s, a_s.default_access_mode()),
+                None => (AddressSpace::Function, AccessMode::ReadWrite),
+            };
+            Type::Ref(a_s, Box::new(ty), a_m)
+        } else {
+            ty
+        };
+
         if ctx
             .scope
-            .add(self.ident.to_string(), Instance::Deferred(ty))
+            .add(self.ident.to_string(), Instance::Deferred(inst_ty))
         {
             Ok(())
         } else {
@@ -550,7 +561,7 @@ impl Lower for TranslationUnit {
                         .scope
                         .get(&decl.ident.name())
                         .expect("module-scope declaration not present in scope");
-                    let ty = inst.ty();
+                    let ty = inst.ty().loaded();
 
                     if ty.is_concrete() {
                         decl.ty = Some(ty.to_expr(ctx)?.unwrap_type_or_identifier());

--- a/crates/wesl/src/eval/lower.rs
+++ b/crates/wesl/src/eval/lower.rs
@@ -1,6 +1,6 @@
 use std::iter::zip;
-use wgsl_types::ty::Ty;
 use wgsl_parse::{Decorated, span::Spanned, syntax::*};
+use wgsl_types::ty::Ty;
 
 use crate::eval::{ATTR_INTRINSIC, Context, Eval, EvalError, Exec, ty_eval_ty};
 

--- a/crates/wesl/src/eval/to_expr.rs
+++ b/crates/wesl/src/eval/to_expr.rs
@@ -13,7 +13,7 @@ use wgsl_parse::{span::Spanned, syntax::*};
 
 type E = EvalError;
 
-/// Convert and instance to an Expression.
+/// Convert an instance to an Expression.
 pub trait ToExpr {
     fn to_expr(&self, ctx: &Context) -> Result<Expression, E>;
 }
@@ -218,6 +218,7 @@ impl ToExpr for Type {
                 ty.template_args = Some(args);
                 Ok(ty)
             }
+            Type::Ref(_, _, _) => Err(E::NotConstructible(self.ty())),
             Type::Texture(tex) => {
                 let mut ty = TypeExpression::new(ident.unwrap());
                 ty.template_args = match tex {

--- a/crates/wesl/src/eval/ty.rs
+++ b/crates/wesl/src/eval/ty.rs
@@ -3,16 +3,16 @@ use std::str::FromStr;
 use crate::Eval;
 
 use super::{
-    builtin_fn_type, check_swizzle, constructor_type, convert_ty, is_constructor_fn, with_stage,
-    ArrayTemplate, AtomicTemplate, Context, Convert, EvalAttrs, EvalError, Exec, MatTemplate,
-    PtrTemplate, SamplerType, ScopeKind, StructType, SyntaxUtil, TextureTemplate, TextureType, Ty,
-    Type, VecTemplate, ATTR_INTRINSIC,
+    ATTR_INTRINSIC, ArrayTemplate, AtomicTemplate, Context, Convert, EvalAttrs, EvalError, Exec,
+    MatTemplate, PtrTemplate, SamplerType, ScopeKind, StructType, SyntaxUtil, TextureTemplate,
+    TextureType, Ty, Type, VecTemplate, builtin_fn_type, check_swizzle, constructor_type,
+    convert_ty, is_constructor_fn, with_stage,
 };
 
 type E = EvalError;
 
-use wgsl_parse::{span::Spanned, syntax::*, Decorated};
-use wgsl_types::{enums::Enumerant, tplt::TpltParam, ty::StructMemberType, ShaderStage};
+use wgsl_parse::{Decorated, span::Spanned, syntax::*};
+use wgsl_types::{ShaderStage, enums::Enumerant, tplt::TpltParam, ty::StructMemberType};
 
 pub fn eval_tplt_arg(tplt: &TemplateArg, ctx: &mut Context) -> Result<TpltParam, E> {
     with_stage!(ctx, ShaderStage::Const, {

--- a/crates/wesl/src/eval/ty.rs
+++ b/crates/wesl/src/eval/ty.rs
@@ -320,10 +320,10 @@ impl EvalTy for UnaryExpression {
             UnaryOperator::Negation if inner.is_scalar() && !inner.is_u32() => Ok(ty),
             UnaryOperator::BitwiseComplement if inner.is_integer() => Ok(ty),
             UnaryOperator::AddressOf => unreachable!("handled above"),
-            UnaryOperator::Indirection if ty.is_ptr() => {
-                let (address_space, inner, access_mode) = ty.unwrap_ptr();
-                Ok(Type::Ref(address_space, inner, access_mode))
-            }
+            UnaryOperator::Indirection => match ty {
+                Type::Ptr(a_s, ty, a_m) => Ok(Type::Ref(a_s, ty, a_m)),
+                _ => Err(E::Unary(self.operator, ty)),
+            },
             _ => Err(E::Unary(self.operator, ty)),
         }
     }

--- a/crates/wgsl-syntax/src/lib.rs
+++ b/crates/wgsl-syntax/src/lib.rs
@@ -171,7 +171,9 @@ pub enum UnaryOperator {
     LogicalNegation,
     Negation,
     BitwiseComplement,
+    /// `&`
     AddressOf,
+    /// `*`
     Indirection,
 }
 

--- a/crates/wgsl-syntax/src/lib.rs
+++ b/crates/wgsl-syntax/src/lib.rs
@@ -168,8 +168,11 @@ pub enum InterpolationSampling {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, IsVariant)]
 pub enum UnaryOperator {
+    /// `!`
     LogicalNegation,
+    /// `-`
     Negation,
+    /// `~`
     BitwiseComplement,
     /// `&`
     AddressOf,
@@ -181,23 +184,41 @@ pub enum UnaryOperator {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, IsVariant)]
 pub enum BinaryOperator {
+    /// `||`
     ShortCircuitOr,
+    /// `&&`
     ShortCircuitAnd,
+    /// `+`
     Addition,
+    /// `-`
     Subtraction,
+    /// `*`
     Multiplication,
+    /// `/`
     Division,
+    /// `%`
     Remainder,
+    /// `==`
     Equality,
+    /// `!=`
     Inequality,
+    /// `<`
     LessThan,
+    /// `<=`
     LessThanEqual,
+    /// `>`
     GreaterThan,
+    /// `>=`
     GreaterThanEqual,
+    /// `|`
     BitwiseOr,
+    /// `&`
     BitwiseAnd,
+    /// `^`
     BitwiseXor,
+    /// `<<`
     ShiftLeft,
+    /// `>>`
     ShiftRight,
 }
 
@@ -205,16 +226,27 @@ pub enum BinaryOperator {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, IsVariant)]
 pub enum AssignmentOperator {
+    /// `=`
     Equal,
+    /// `+=`
     PlusEqual,
+    /// `-=`
     MinusEqual,
+    /// `*=`
     TimesEqual,
+    /// `/=`
     DivisionEqual,
+    /// `%=`
     ModuloEqual,
+    /// `&=`
     AndEqual,
+    /// `|=`
     OrEqual,
+    /// `^=`
     XorEqual,
+    /// `>>=`
     ShiftRightAssign,
+    /// `<<=`
     ShiftLeftAssign,
 }
 

--- a/crates/wgsl-syntax/src/lib.rs
+++ b/crates/wgsl-syntax/src/lib.rs
@@ -23,6 +23,21 @@ pub enum AddressSpace {
     PushConstant,
 }
 
+impl AddressSpace {
+    pub fn default_access_mode(&self) -> AccessMode {
+        match self {
+            AddressSpace::Function => AccessMode::ReadWrite,
+            AddressSpace::Private => AccessMode::ReadWrite,
+            AddressSpace::Workgroup => AccessMode::ReadWrite,
+            AddressSpace::Uniform => AccessMode::Read,
+            AddressSpace::Storage => AccessMode::Read,
+            AddressSpace::Handle => AccessMode::Read,
+            #[cfg(feature = "naga_ext")]
+            AddressSpace::PushConstant => AccessMode::Read,
+        }
+    }
+}
+
 /// Memory access mode enumeration.
 ///
 /// Reference: <https://www.w3.org/TR/WGSL/#access-mode>

--- a/crates/wgsl-types/src/builtin/call.rs
+++ b/crates/wgsl-types/src/builtin/call.rs
@@ -1,5 +1,6 @@
 //! Built-in functions call implementations.
 //!
+//! The arguments must be [loaded][Type::loaded].
 //! Functions bear the same name as the WGSL counterpart.
 //! Functions that take template parameters are suffixed with `_t`.
 //!

--- a/crates/wgsl-types/src/builtin/mod.rs
+++ b/crates/wgsl-types/src/builtin/mod.rs
@@ -201,6 +201,8 @@ fn vec_ctor_ty(n: u8, args: &[Type]) -> Result<Type, E> {
 }
 
 /// Compute the return type of calling a built-in constructor function.
+///
+/// The arguments must be [loaded][Type::loaded].
 pub fn constructor_type(name: &str, tplt: Option<&[TpltParam]>, args: &[Type]) -> Result<Type, E> {
     match (name, tplt, args) {
         ("array", Some(t), []) => Ok(ArrayTemplate::parse(t)?.ty()),
@@ -344,6 +346,8 @@ fn modf_struct_type(ty: &Type) -> Option<StructType> {
 }
 
 /// Compute the return type of calling a built-in function.
+///
+/// The arguments must be [loaded][Type::loaded].
 ///
 /// Does not include constructor built-ins, see [`constructor_type`].
 /// Some functions are still TODO, see [`call`] for the list of functions and statuses.
@@ -916,6 +920,8 @@ impl MatInstance {
 }
 
 /// Call a built-in function.
+///
+/// The arguments must be [loaded][Type::loaded].
 ///
 /// Includes constructor built-ins.
 /// Some functions are still TODO, see [`call`] for the list of functions and statuses.

--- a/crates/wgsl-types/src/builtin/mod.rs
+++ b/crates/wgsl-types/src/builtin/mod.rs
@@ -802,7 +802,7 @@ impl Instance {
             Type::BindingArray(_, _) => Err(E::NotConstructible(ty.clone())),
             Type::Vec(n, v_ty) => VecInstance::zero_value(*n, v_ty).map(Into::into),
             Type::Mat(c, r, m_ty) => MatInstance::zero_value(*c, *r, m_ty).map(Into::into),
-            Type::Atomic(_) | Type::Ptr(_, _, _) | Type::Texture(_) | Type::Sampler(_) => {
+            Type::Atomic(_) | Type::Ptr(_, _, _) | Type::Ref(_, _, _) | Type::Texture(_) | Type::Sampler(_) => {
                 Err(E::NotConstructible(ty.clone()))
             }
         }

--- a/crates/wgsl-types/src/conv.rs
+++ b/crates/wgsl-types/src/conv.rs
@@ -8,6 +8,7 @@
 use half::f16;
 use itertools::Itertools;
 use num_traits::{FromPrimitive, ToPrimitive};
+use wgsl_syntax::AccessMode;
 
 use crate::{
     Instance,
@@ -269,6 +270,9 @@ pub fn conversion_rank(ty1: &Type, ty2: &Type) -> Option<u32> {
     // reference: <https://www.w3.org/TR/WGSL/#conversion-rank>
     match (ty1, ty2) {
         (_, _) if ty1 == ty2 => Some(0),
+        (Type::Ref(_, ty1, AccessMode::Read | AccessMode::ReadWrite), ty2) if &**ty1 == ty2 => {
+            Some(0)
+        }
         (Type::AbstractInt, Type::AbstractFloat) => Some(5),
         (Type::AbstractInt, Type::I32) => Some(3),
         (Type::AbstractInt, Type::U32) => Some(4),

--- a/crates/wgsl-types/src/conv.rs
+++ b/crates/wgsl-types/src/conv.rs
@@ -81,6 +81,17 @@ impl Type {
             _ => self.clone(),
         }
     }
+
+    /// Apply the load rule.
+    ///
+    /// Reference: <https://www.w3.org/TR/WGSL/#load-rule>
+    pub fn loaded(self) -> Self {
+        if let Type::Ref(_, ty, _) = self {
+            ty.loaded()
+        } else {
+            self
+        }
+    }
 }
 
 impl LiteralInstance {

--- a/crates/wgsl-types/src/display.rs
+++ b/crates/wgsl-types/src/display.rs
@@ -225,6 +225,7 @@ impl Display for Type {
             Type::Mat(m, n, ty) => write!(f, "mat{m}x{n}<{ty}>"),
             Type::Atomic(ty) => write!(f, "atomic<{ty}>"),
             Type::Ptr(a_s, ty, a_m) => write!(f, "ptr<{a_s}, {ty}, {a_m}>"),
+            Type::Ref(a_s, ty, a_m) => write!(f, "ref<{a_s}, {ty}, {a_m}>"),
             Type::Texture(texture_type) => texture_type.fmt(f),
             Type::Sampler(sampler_type) => sampler_type.fmt(f),
         }

--- a/crates/wgsl-types/src/inst.rs
+++ b/crates/wgsl-types/src/inst.rs
@@ -475,6 +475,7 @@ impl From<RefInstance> for PtrInstance {
 /// Reference: <https://www.w3.org/TR/WGSL/#ref-ptr-types>
 #[derive(Clone, Debug, PartialEq)]
 pub struct RefInstance {
+    /// Inner type
     pub ty: Type,
     pub space: AddressSpace,
     pub access: AccessMode,
@@ -548,8 +549,8 @@ impl RefInstance {
         if !self.access.is_write() {
             return Err(E::NotWrite);
         }
-        if value.ty() != self.ty() {
-            return Err(E::WriteRefType(value.ty(), self.ty()));
+        if value.ty() != self.ty {
+            return Err(E::WriteRefType(value.ty(), self.ty.clone()));
         }
         let mut r = self.ptr.borrow_mut();
         let view = r.view_mut(&self.view).expect("invalid reference");

--- a/crates/wgsl-types/src/mem.rs
+++ b/crates/wgsl-types/src/mem.rs
@@ -168,7 +168,7 @@ impl Instance {
                 };
                 Some(AtomicInstance::new(inst).into())
             }
-            Type::Ptr(_, _, _) | Type::Texture(_) | Type::Sampler(_) => None,
+            Type::Ptr(_, _, _) | Type::Ref(_, _, _) | Type::Texture(_) | Type::Sampler(_) => None,
         }
     }
 }
@@ -322,7 +322,7 @@ impl Type {
                 Some(*c as u32 * align)
             }
             Type::Atomic(_) => Some(4),
-            Type::Ptr(_, _, _) | Type::Texture(_) | Type::Sampler(_) => None,
+            Type::Ptr(_, _, _) | Type::Ref(_, _, _) | Type::Texture(_) | Type::Sampler(_) => None,
         }
     }
 
@@ -370,7 +370,7 @@ impl Type {
             }
             Type::Mat(_, r, ty) => Type::Vec(*r, ty.clone()).align_of(),
             Type::Atomic(_) => Some(4),
-            Type::Ptr(_, _, _) | Type::Texture(_) | Type::Sampler(_) => None,
+            Type::Ptr(_, _, _) | Type::Ref(_, _, _) | Type::Texture(_) | Type::Sampler(_) => None,
         }
     }
 }

--- a/crates/wgsl-types/src/ty.rs
+++ b/crates/wgsl-types/src/ty.rs
@@ -322,9 +322,6 @@ impl Type {
     pub fn is_f32(&self) -> bool {
         matches!(self, Type::F32)
     }
-    pub fn is_ptr(&self) -> bool {
-        matches!(self, Type::Ptr(_, _, _))
-    }
     pub fn is_bool(&self) -> bool {
         matches!(self, Type::Bool)
     }

--- a/crates/wgsl-types/src/ty.rs
+++ b/crates/wgsl-types/src/ty.rs
@@ -457,7 +457,7 @@ impl Ty for PtrInstance {
 
 impl Ty for RefInstance {
     fn ty(&self) -> Type {
-        self.ty.clone()
+        Type::Ref(self.space, Box::new(self.ty.clone()), self.access)
     }
 }
 

--- a/crates/wgsl-types/src/ty.rs
+++ b/crates/wgsl-types/src/ty.rs
@@ -242,6 +242,7 @@ pub enum Type {
     Mat(u8, u8, Box<Type>),
     Atomic(Box<Type>),
     Ptr(AddressSpace, Box<Type>, AccessMode),
+    Ref(AddressSpace, Box<Type>, AccessMode),
     Texture(TextureType),
     Sampler(SamplerType),
 }
@@ -352,6 +353,7 @@ impl Ty for Type {
             Type::Mat(_, _, ty) => ty.ty(),
             Type::Atomic(ty) => ty.ty(),
             Type::Ptr(_, ty, _) => ty.ty(),
+            Type::Ref(_, ty, _) => ty.ty(),
             Type::Texture(_) => self.clone(),
             Type::Sampler(_) => self.clone(),
         }


### PR DESCRIPTION
I started adding `Type::Ref`. However, I'm not yet familiar enough with everything to do a complete implementation in one go.

I'm reasonably sure that those places need updating
https://github.com/wgsl-tooling-wg/wesl-rs/blob/e4d114db3b86102b2e12562cda677445d0af17c2/crates/wesl/src/eval/ty.rs#L914

And I'm unsure about those
https://github.com/wgsl-tooling-wg/wesl-rs/blob/e4d114db3b86102b2e12562cda677445d0af17c2/crates/wesl/src/eval/conv.rs#L52
https://github.com/wgsl-tooling-wg/wesl-rs/blob/e4d114db3b86102b2e12562cda677445d0af17c2/crates/wesl-cli/src/main.rs#L474
https://github.com/wgsl-tooling-wg/wesl-rs/blob/e4d114db3b86102b2e12562cda677445d0af17c2/crates/wesl-web/src/lib.rs#L233


https://github.com/wgsl-tooling-wg/wesl-rs/blob/e4d114db3b86102b2e12562cda677445d0af17c2/crates/wesl/src/eval/lower.rs#L225

I think these can stay unchanged
https://github.com/wgsl-tooling-wg/wesl-rs/blob/e4d114db3b86102b2e12562cda677445d0af17c2/crates/wesl/src/eval/lower.rs#L540
