### PR TITLE
Error with imported name collisions

### DIFF
--- a/crates/wesl-test/spec-tests/imports.json
+++ b/crates/wesl-test/spec-tests/imports.json
@@ -1,0 +1,31 @@
+[
+    {
+        "name": "dupl-decl",
+        "desc": "two declarations have the same name",
+        "kind": "context",
+        "code": "const foo: u32 = 0; const foo: u32 = 0;",
+        "expect": "fail"
+    },
+    {
+        "name": "dupl-decl-import",
+        "desc": "cannot import the same identifier twice",
+        "kind": "context",
+        "code": "import some::foo; import package::foo;",
+        "expect": "fail"
+    },
+    {
+        "name": "dupl-decl-import-renamed",
+        "desc": "same ident is imported twice, but one is renamed",
+        "kind": "context",
+        "code": "import some::foo as bar; import package::foo;",
+        "expect": "pass"
+    },
+    {
+        "name": "dupl-decl-conflict-local",
+        "desc": "imported ident conflicts with local declaration",
+        "kind": "context",
+        "code": "import some::foo; const foo: u32 = 0;",
+        "expect": "fail",
+        "issue": "117"
+    }
+]

--- a/crates/wesl-test/src/schemas.rs
+++ b/crates/wesl-test/src/schemas.rs
@@ -150,6 +150,7 @@ impl fmt::Display for TestKind {
 
 #[derive(Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[derive(Clone, Copy)]
 pub enum Expectation {
     Pass,
     Fail,

--- a/crates/wesl-test/tests/testsuite.rs
+++ b/crates/wesl-test/tests/testsuite.rs
@@ -6,7 +6,7 @@
 
 use std::{ffi::OsStr, path::PathBuf, process::Command, str::FromStr};
 
-use wesl::{CompileOptions, EscapeMangler, NoMangler, VirtualResolver, syntax::*};
+use wesl::{CompileOptions, EscapeMangler, NoMangler, VirtualResolver, syntax::*, validate_wesl};
 use wesl_test::schemas::*;
 
 fn eprint_test(case: &Test) {
@@ -48,33 +48,25 @@ fn eprint_wgsl_test(case: &WgslTestSrc) {
 fn main() {
     let mut tests: Vec<libtest_mimic::Trial> = Vec::new();
 
-    tests.extend({
-        let file = std::fs::read_to_string("spec-tests/lit-type-inference.json")
-            .expect("failed to read test file");
-        let json: Vec<Test> = serde_json::from_str(&file).expect("failed to parse json file");
-        json.into_iter().map(|case| {
-            let name = format!("lit-type-inference.json::{}", case.name);
-            let ignored = case.skip.unwrap_or(false);
-            libtest_mimic::Trial::test(name, move || {
-                json_case(&case).inspect_err(|_| eprint_test(&case))
+    let spec_tests = [
+        "spec-tests/idents.json",
+        "spec-tests/lit-type-inference.json",
+        "spec-tests/imports.json",
+    ];
+    for path in spec_tests {
+        tests.extend({
+            let file = std::fs::read_to_string(path).expect("failed to read test file");
+            let json: Vec<Test> = serde_json::from_str(&file).expect("failed to parse json file");
+            json.into_iter().map(|case| {
+                let name = format!("{path}::{}", case.name);
+                let ignored = case.skip.unwrap_or(false);
+                libtest_mimic::Trial::test(name, move || {
+                    json_case(&case).inspect_err(|_| eprint_test(&case))
+                })
+                .with_ignored_flag(ignored)
             })
-            .with_ignored_flag(ignored)
-        })
-    });
-
-    tests.extend({
-        let file =
-            std::fs::read_to_string("spec-tests/idents.json").expect("failed to read test file");
-        let json: Vec<Test> = serde_json::from_str(&file).expect("failed to parse json file");
-        json.into_iter().map(|case| {
-            let name = format!("idents.json::{}", case.name);
-            let ignored = case.skip.unwrap_or(false);
-            libtest_mimic::Trial::test(name, move || {
-                json_case(&case).inspect_err(|_| eprint_test(&case))
-            })
-            .with_ignored_flag(ignored)
-        })
-    });
+        });
+    }
 
     tests.extend({
         let file =
@@ -252,16 +244,11 @@ fn json_case(case: &Test) -> Result<(), libtest_mimic::Failed> {
                 SyntaxKind::Statement => case.code.parse::<Statement>().map(|_| ()),
                 SyntaxKind::Expression => case.code.parse::<Expression>().map(|_| ()),
             };
-            match res {
-                Ok(()) => {
-                    if case.expect == Expectation::Fail {
-                        return Err("expected Fail, got Pass".into());
-                    }
-                }
-                Err(e) => {
-                    if case.expect == Expectation::Pass {
-                        return Err(format!("expected Pass, got Fail (`{e}`)").into());
-                    }
+            match (res, case.expect) {
+                (Err(_), Expectation::Fail) | (Ok(()), Expectation::Pass) => Ok(()),
+                (Ok(()), Expectation::Fail) => Err("expected Fail, got Pass".into()),
+                (Err(e), Expectation::Pass) => {
+                    Err(format!("expected Pass, got Fail (`{e}`)").into())
                 }
             }
         }
@@ -269,29 +256,41 @@ fn json_case(case: &Test) -> Result<(), libtest_mimic::Failed> {
             let wesl = case.code.parse::<TranslationUnit>()?;
             let expr = eval.parse::<Expression>()?;
             let (eval_inst, _) = wesl::eval(&expr, &wesl);
-            match result {
-                Some(expect) => {
+            let expect = result
+                .as_ref()
+                .map(|expect| -> Result<_, wesl::Error> {
                     let expr = expect.parse::<Expression>()?;
                     let (expect_inst, _) = wesl::eval(&expr, &wesl);
-                    let expect_inst = expect_inst?;
-                    let eval_inst = eval_inst?;
-                    if eval_inst != expect_inst {
-                        return Err(format!("expected `{expect_inst}`, got `{eval_inst}`").into());
+                    Ok(expect_inst?)
+                })
+                .transpose()?;
+            match (eval_inst, expect) {
+                (Err(_), None) => Ok(()),
+                (Ok(inst), Some(expect)) => {
+                    if inst != expect {
+                        Err(format!("expected `{expect}`, got `{inst}`").into())
+                    } else {
+                        Ok(())
                     }
                 }
-                None => {
-                    if let Ok(inst) = eval_inst {
-                        return Err(format!("expected Fail, got Pass (`{inst}`)").into());
-                    }
+                (Ok(inst), None) => Err(format!("expected Fail, got Pass (`{inst}`)").into()),
+                (Err(err), Some(expect)) => {
+                    Err(format!("expected `{expect}`, got Fail (`{err}`)").into())
                 }
-            };
+            }
         }
         TestKind::Context => {
-            panic!("TODO: context tests")
+            let wesl = case.code.parse::<TranslationUnit>()?;
+            let valid = validate_wesl(&wesl);
+            match (valid, case.expect) {
+                (Err(_), Expectation::Fail) | (Ok(()), Expectation::Pass) => Ok(()),
+                (Ok(()), Expectation::Fail) => Err("expected Fail, got Pass".into()),
+                (Err(e), Expectation::Pass) => {
+                    Err(format!("expected Pass, got Fail (`{e}`)").into())
+                }
+            }
         }
     }
-
-    Ok(())
 }
 
 fn testsuite_syntax_case(case: &ParsingTest) -> Result<(), libtest_mimic::Failed> {

--- a/crates/wesl/src/import.rs
+++ b/crates/wesl/src/import.rs
@@ -58,16 +58,6 @@ impl Module {
             .collect::<HashMap<_, _>>();
         let imports = flatten_imports(&source.imports, &path)?;
 
-        // TODO: this is not correct because of conditional compilation.
-        // for id in idents.keys() {
-        //     if imports
-        //         .keys()
-        //         .any(|k| k.name().as_str() == id.name().as_str())
-        //     {
-        //         return Err(E::DuplicateSymbol(id.to_string()));
-        //     }
-        // }
-
         Ok(Self {
             source,
             path,
@@ -387,13 +377,6 @@ fn flatten_imports(imports: &[ImportStatement], parent_path: &ModulePath) -> Res
         match content {
             ImportContent::Item(item) => {
                 let ident = item.rename.as_ref().unwrap_or(&item.ident).clone();
-                // TODO: this is not correct because of conditional compilation.
-                // if res
-                //     .keys()
-                //     .any(|k| k.name().as_str() == ident.name().as_str())
-                // {
-                //     return Err(E::DuplicateSymbol(ident.to_string()));
-                // }
                 res.insert(
                     ident,
                     ImportItem {

--- a/crates/wesl/src/validate/mod.rs
+++ b/crates/wesl/src/validate/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 use wesl_macros::query;
 use wgsl_parse::Decorated;
 use wgsl_parse::syntax::{
-    Expression, ExpressionNode, FunctionCall, GlobalDeclaration, Ident, TranslationUnit,
-    TypeExpression,
+    Expression, ExpressionNode, FunctionCall, GlobalDeclaration, Ident, ImportContent,
+    TranslationUnit, TypeExpression,
 };
 
 use crate::builtin::{BUILTIN_CONSTRUCTOR_NAMES, BUILTIN_FUNCTION_NAMES, builtin_ident};
@@ -171,6 +171,46 @@ fn check_function_calls(wesl: &TranslationUnit) -> Result<(), Diagnostic<Error>>
 
 fn check_duplicate_decl(wesl: &TranslationUnit) -> Result<(), Diagnostic<Error>> {
     let mut unique = HashSet::new();
+
+    fn check_ident(id: &Ident, unique: &mut HashSet<String>) -> Result<(), Diagnostic<Error>> {
+        if unique.contains(id.name().as_str()) {
+            Err(Diagnostic::from(E::Duplicate(id.to_string())).with_declaration(id.to_string()))
+        } else {
+            unique.insert(id.to_string());
+            Ok(())
+        }
+    }
+
+    fn check_import_content(
+        cont: &ImportContent,
+        unique: &mut HashSet<String>,
+    ) -> Result<(), Diagnostic<Error>> {
+        match cont {
+            ImportContent::Item(item) => {
+                let id = item.rename.as_ref().unwrap_or(&item.ident);
+                check_ident(id, unique)?;
+            }
+            ImportContent::Collection(coll) => {
+                for item in coll {
+                    check_import_content(&item.content, unique)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    for import in &wesl.imports {
+        if import
+            .attributes()
+            .iter()
+            .any(|attr| attr.is_if() || attr.is_elif() || attr.is_else())
+        {
+            // we skip checking declarations that have conditional compilation flags.
+            continue;
+        }
+        check_import_content(&import.content, &mut unique)?;
+    }
+
     for decl in &wesl.global_declarations {
         if decl
             .attributes()
@@ -181,11 +221,7 @@ fn check_duplicate_decl(wesl: &TranslationUnit) -> Result<(), Diagnostic<Error>>
             continue;
         }
         if let Some(id) = decl.ident() {
-            if !unique.insert(id.to_string()) {
-                return Err(
-                    Diagnostic::from(E::Duplicate(id.to_string())).with_declaration(id.to_string())
-                );
-            }
+            check_ident(id, &mut unique)?;
         }
     }
     Ok(())


### PR DESCRIPTION
fixed #126

The checks for duplicate declarations in imports were disabled because conditional translation can mess things up.

```rs
@if(SOME_CONDITION)
import some::foo;
@if(SOME_OTHER_CONDITION)
import some::other::foo;
@if(YET_ANOTHER_CONDITION)
const foo: u32 = 0;
```

The stricter rule should be: ERROR if there exists a set of conditionals, such as there are two conflicting idents.
A good compromise: ERROR if at least one of the conflicting idents has no conditions.
The relaxed rule (this PR): ERROR if two conflicting idents have not conditions. (just ignore conditioned declarations)

I re-added the check in the validation pass instead, and basic tests.